### PR TITLE
feat(workflow): support flexible version formats

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -36,7 +36,7 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
   # Allowed upstream repositories (security: prevent arbitrary repo checkout)
-  ALLOWED_UPSTREAMS: "lvu/firemerge"
+  ALLOWED_UPSTREAMS: "lvu/firemerge anthony-spruyt/firemerge"
 
 jobs:
   detect-changes:
@@ -114,9 +114,9 @@ jobs:
             exit 1
           fi
 
-          # Validate version format (semver-like or 'latest')
-          if ! echo "$VERSION" | grep -qE '^([0-9]+\.[0-9]+\.[0-9]+|latest)$'; then
-            echo "::error::Invalid version format: $VERSION"
+          # Validate version format (alphanumeric with common separators, no shell chars)
+          if ! echo "$VERSION" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
+            echo "::error::Invalid version format: $VERSION (must be alphanumeric with .-/_)"
             exit 1
           fi
 
@@ -130,9 +130,9 @@ jobs:
           METADATA_VERSION: ${{ steps.metadata.outputs.version }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
-            # Validate input version format (semver-like, no special chars)
-            if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "::error::Invalid version format. Must be semver (e.g., 1.2.3)"
+            # Validate input version format (alphanumeric with common separators, no shell chars)
+            if ! echo "$INPUT_VERSION" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
+              echo "::error::Invalid version format (must be alphanumeric with .-/_)"
               exit 1
             fi
             echo "tag=$INPUT_VERSION" >> "$GITHUB_OUTPUT"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -3,18 +3,5 @@
 # https://trivy.dev/latest/docs/configuration/filtering
 
 vulnerabilities:
-  # CVE-2024-47874: Starlette DoS via multipart parsing
-  # Risk: LOW - Service is behind Authentik forward proxy auth, single-user deployment
-  - id: CVE-2024-47874
-    paths:
-      - firemerge/**
-    statement: "Accepted risk: Single-user deployment behind Authentik auth proxy"
-
-  # CVE-2025-64512: pdfminer.six PDF parsing vulnerability
-  # Risk: LOW - Single-user deployment, no untrusted PDF uploads
-  - id: CVE-2025-64512
-    paths:
-      - firemerge/**
-    statement: "Accepted risk: Single-user deployment, no untrusted PDF uploads"
 
 misconfigurations:

--- a/firemerge/metadata.yaml
+++ b/firemerge/metadata.yaml
@@ -2,5 +2,5 @@
 # Firemerge - Semi-automated transaction entry for Firefly III
 # https://github.com/lvu/firemerge
 
-upstream: lvu/firemerge
-version: "0.5.2"
+upstream: anthony-spruyt/firemerge
+version: security/fix-cve-2025-64512-cve-2024-47874


### PR DESCRIPTION
## Summary

- Relax version validation to support various formats:
  - Semver: `1.2.3`
  - Pre-release: `1.2.3-fix`, `v1.2.3-beta.1`
  - Branch names: `main`, `security/fix-cve`
  - CalVer: `2025.01.15`
- Add `anthony-spruyt/firemerge` to allowed upstreams
- Point firemerge to security fix branch (pending upstream merge)
- Clear trivyignore entries (CVEs fixed in branch)

## Test plan

- [ ] Dry-run build from branch passes Trivy scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)