### PR TITLE
fix(trivy): add CVE-2025-62727 to ignored vulnerabilities

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -3,5 +3,11 @@
 # https://trivy.dev/latest/docs/configuration/filtering
 
 vulnerabilities:
+  # firemerge: DoS via Range header merging in starlette
+  # Risk accepted: behind Authentik forward proxy auth, single user
+  # Fixed in starlette 0.49.1, pending upstream update
+  - id: CVE-2025-62727
+    paths:
+      - firemerge
 
 misconfigurations:


### PR DESCRIPTION
## Summary
- New starlette vulnerability CVE-2025-62727 (DoS via Range header merging)
- Fixed in starlette 0.49.1, pending upstream update
- Risk accepted: firemerge is behind Authentik forward proxy auth, single user

## Test plan
- [ ] Merge and trigger dry-run build
- [ ] Verify Trivy scan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)