### PR TITLE
fix(trivy): correct trivyignore format

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,13 +1,12 @@
 ---
-# Path-specific trivy ignores
+# Trivy vulnerability ignores
 # https://trivy.dev/latest/docs/configuration/filtering
+#
+# Risk accepted: firemerge is behind Authentik forward proxy auth, single user
+# These DoS vulnerabilities have minimal impact in this deployment context.
 
 vulnerabilities:
-  # firemerge: DoS via Range header merging in starlette
-  # Risk accepted: behind Authentik forward proxy auth, single user
-  # Fixed in starlette 0.49.1, pending upstream update
+  # starlette: DoS via Range header merging (fixed in 0.49.1)
   - id: CVE-2025-62727
-    paths:
-      - firemerge
 
 misconfigurations:


### PR DESCRIPTION
## Summary
- Path filtering in trivyignore refers to file paths, not image names
- Use simpler global ignore for CVE-2025-62727

## Test plan
- [ ] Merge and trigger dry-run build
- [ ] Verify Trivy scan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)