### PR TITLE
fix(trivy): clear CVE ignores after upstream fix

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,12 +1,7 @@
 ---
-# Trivy vulnerability ignores
+# Path-specific trivy ignores
 # https://trivy.dev/latest/docs/configuration/filtering
-#
-# Risk accepted: firemerge is behind Authentik forward proxy auth, single user
-# These DoS vulnerabilities have minimal impact in this deployment context.
 
 vulnerabilities:
-  # starlette: DoS via Range header merging (fixed in 0.49.1)
-  - id: CVE-2025-62727
 
 misconfigurations:


### PR DESCRIPTION
## Summary
- Upstream fork now includes fix for CVE-2025-62727 (starlette DoS)
- Clear trivyignore entries since no longer needed

## Test plan
- [ ] Merge and trigger dry-run build
- [ ] Verify Trivy scan passes without ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)