### PR TITLE
fix(workflow): remove unnecessary gh CLI auth check

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -131,7 +131,6 @@ jobs:
       - name: Validate configuration
         id: validate
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_NAME: ${{ matrix.image }}
           ALLOWED_UPSTREAMS: ${{ env.ALLOWED_UPSTREAMS }}
           VERSION: ${{ steps.metadata.outputs.version }}
@@ -169,12 +168,6 @@ jobs:
           RELEASE_TAG="${IMAGE_NAME}-v${TAG}"
           if ! echo "$RELEASE_TAG" | grep -qE '^[a-zA-Z0-9_-]+-v[a-zA-Z0-9._-]+$'; then
             echo "::error::Release tag '$RELEASE_TAG' has invalid format"
-            ERRORS=$((ERRORS + 1))
-          fi
-
-          # Verify gh CLI authentication (read-only)
-          if ! gh api user --jq '.login' &>/dev/null; then
-            echo "::error::GitHub CLI authentication failed"
             ERRORS=$((ERRORS + 1))
           fi
 


### PR DESCRIPTION
## Summary

Removes the `gh api user` authentication check from the validation step.

## Reason

GITHUB_TOKEN is auto-generated by GitHub Actions and guaranteed to be valid for the workflow run. Testing it:
- Adds no value (it will always work)
- Previously failed because `gh api user` requires user scope which GITHUB_TOKEN doesn't have

## Test plan

- [x] Pre-commit passes
- [ ] Dry run workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)