### PR TITLE
feat(firemerge): add n8n workflow for release detection

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,5 @@
 # Ignore GitHub Actions template variables in workflow files
 https://github.com/\$%7BUPSTREAM%7D
+
+# Ignore GitHub API endpoints (require POST with auth, lychee does GET)
+https://api.github.com/repos/.*/actions/workflows/.*/dispatches

--- a/firemerge/README.md
+++ b/firemerge/README.md
@@ -1,0 +1,73 @@
+# Firemerge Container Image
+
+Semi-automated transaction entry for Firefly III.
+
+- **Upstream:** <https://github.com/lvu/firemerge>
+- **Container:** `ghcr.io/anthony-spruyt/firemerge`
+
+## n8n Release Watcher
+
+The `n8n-release-watcher.json` workflow automatically detects new Firemerge releases and triggers a container build.
+
+### What it does
+
+1. Checks GitHub daily (midnight UTC) for new tags on `lvu/firemerge`
+2. Compares with the last processed version (stored in workflow static data)
+3. If a new version is found:
+   - Triggers the container build workflow
+   - Sends an email notification
+   - Updates the stored version
+
+### Import into n8n
+
+1. In n8n, go to **Workflows** > **Add Workflow** > **Import from File**
+2. Select `n8n-release-watcher.json`
+3. Configure the credentials (see below)
+4. Activate the workflow
+
+### Required Credentials
+
+#### 1. GitHub Personal Access Token (Header Auth)
+
+Create a GitHub PAT with `repo` and `workflow` scopes:
+
+1. Go to GitHub > Settings > Developer settings > Personal access tokens > Fine-grained tokens
+2. Create a new token with:
+   - **Repository access:** `anthony-spruyt/container-images`
+   - **Permissions:** Actions (Read and write)
+3. In n8n, go to **Credentials** > **Add Credential** > **Header Auth**
+4. Configure:
+   - **Name:** `GitHub PAT`
+   - **Header Name:** `Authorization`
+   - **Header Value:** `Bearer <your-token>`
+
+#### 2. SMTP Credential
+
+1. In n8n, go to **Credentials** > **Add Credential** > **SMTP**
+2. Configure your SMTP server settings:
+   - **Host:** Your SMTP server hostname
+   - **Port:** 587 (TLS) or 465 (SSL)
+   - **User:** Your SMTP username
+   - **Password:** Your SMTP password
+   - **SSL/TLS:** Enable as required
+
+### Configuration After Import
+
+1. Open the **Trigger Build Workflow** node and select your GitHub PAT credential
+2. Open the **Send Notification** node:
+   - Select your SMTP credential
+   - Update `fromEmail` to your sender address
+   - Update `toEmail` to your notification recipient
+3. Save and activate the workflow
+
+### Testing
+
+1. Open the workflow in n8n
+2. Click **Execute Workflow** to run manually
+3. Check the output of each node:
+   - **Get GitHub Tags:** Should return tag list from GitHub
+   - **Check New Version:** Shows `isNew: true` on first run
+   - **Trigger Build Workflow:** Should return HTTP 204 (success)
+   - **Send Notification:** Sends email to configured recipient
+
+On subsequent runs, `isNew` will be `false` until a new release is published upstream.

--- a/firemerge/n8n-release-watcher.json
+++ b/firemerge/n8n-release-watcher.json
@@ -1,0 +1,208 @@
+{
+  "name": "Firemerge Release Watcher",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "days",
+              "triggerAtHour": 0
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Daily Check",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "url": "https://api.github.com/repos/lvu/firemerge/tags",
+        "options": {}
+      },
+      "id": "get-tags",
+      "name": "Get GitHub Tags",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [220, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get workflow static data to track last processed version\nconst staticData = $getWorkflowStaticData('global');\n\n// Get the latest tag from the GitHub API response\n// n8n splits the array response into separate items, so first item = latest tag\nconst items = $input.all();\nif (!items || items.length === 0 || !items[0].json) {\n  return [{ json: { isNew: false, version: null, error: 'No tags found' } }];\n}\n\n// First item is the latest tag (GitHub returns tags sorted by creation date desc)\nconst latestTag = items[0].json;\nif (!latestTag.name) {\n  return [{ json: { isNew: false, version: null, error: 'Invalid tag data' } }];\n}\n\n// Extract version (strip 'v' prefix if present)\nlet version = latestTag.name;\nif (version.startsWith('v')) {\n  version = version.substring(1);\n}\n\n// Check if this is a new version\nconst lastVersion = staticData.lastVersion || null;\nconst isNew = lastVersion !== version;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    lastVersion: lastVersion,\n    tagName: latestTag.name,\n    commitSha: latestTag.commit?.sha || null\n  }\n}];"
+      },
+      "id": "check-version",
+      "name": "Check New Version",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [440, 0]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-new-version",
+              "leftValue": "={{ $json.isNew }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-new",
+      "name": "Is New Version?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [660, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.github.com/repos/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml/dispatches",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Accept",
+              "value": "application/vnd.github.v3+json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"firemerge\",\n    \"version\": \"{{ $json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
+        "options": {}
+      },
+      "id": "trigger-build",
+      "name": "Trigger Build Workflow",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [880, -100],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "CONFIGURE_ME",
+          "name": "GitHub PAT"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "fromEmail": "noreply@example.com",
+        "toEmail": "CONFIGURE_ME@example.com",
+        "subject": "=Firemerge {{ $('Check New Version').item.json.version }} - Build triggered",
+        "emailType": "text",
+        "message": "=A new Firemerge release has been detected and a container build has been triggered.\n\nVersion: {{ $('Check New Version').item.json.version }}\nPrevious Version: {{ $('Check New Version').item.json.lastVersion || 'None (first run)' }}\nTag: {{ $('Check New Version').item.json.tagName }}\nCommit: {{ $('Check New Version').item.json.commitSha || 'N/A' }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nUpstream Release:\nhttps://github.com/lvu/firemerge/releases/tag/{{ $('Check New Version').item.json.tagName }}",
+        "options": {}
+      },
+      "id": "send-email",
+      "name": "Send Notification",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [1100, -100],
+      "credentials": {
+        "smtp": {
+          "id": "CONFIGURE_ME",
+          "name": "SMTP"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Update static data with the new version\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
+      },
+      "id": "update-state",
+      "name": "Update State",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, -100]
+    }
+  ],
+  "connections": {
+    "Daily Check": {
+      "main": [
+        [
+          {
+            "node": "Get GitHub Tags",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get GitHub Tags": {
+      "main": [
+        [
+          {
+            "node": "Check New Version",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check New Version": {
+      "main": [
+        [
+          {
+            "node": "Is New Version?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is New Version?": {
+      "main": [
+        [
+          {
+            "node": "Trigger Build Workflow",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Trigger Build Workflow": {
+      "main": [
+        [
+          {
+            "node": "Send Notification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Notification": {
+      "main": [
+        [
+          {
+            "node": "Update State",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": false
+  }
+}


### PR DESCRIPTION
## Summary
- Add n8n workflow (`firemerge/n8n-release-watcher.json`) that monitors `lvu/firemerge` for new releases
- Automatically triggers container builds when new upstream versions are detected
- Sends email notifications on new releases
- Add README with setup and configuration instructions

## Test plan
- [x] Imported workflow into n8n successfully
- [x] Configured GitHub PAT and SMTP credentials
- [x] Tested version detection from upstream tags
- [x] Verified workflow dispatch triggers build correctly
- [x] Confirmed email notification sent with correct version info
- [x] Production build completed successfully (firemerge v0.5.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)