### PR TITLE
fix(ci): fix Trivy scan workflow and add badge

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,11 +6,12 @@
       "Bash(/workspaces/container-images/lint.sh:*)",
       "Skill(hookify:list)",
       "Skill(hookify:list:*)",
-      "Bash(gh issue edit:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh:*)"
+      "Bash(gh:*)",
+      "Bash(find:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/.github/workflows/trivy-weekly-scan.yaml
+++ b/.github/workflows/trivy-weekly-scan.yaml
@@ -94,6 +94,8 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM
           ignore-unfixed: false
           trivyignores: .trivyignore.yaml
+          # Don't fail on vulnerabilities - we process results in next step
+          exit-code: 0
 
       - name: Process results and manage issues
         if: steps.check-image.outputs.exists == 'true'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Lint](https://github.com/anthony-spruyt/container-images/actions/workflows/lint.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/lint.yaml)
 [![Build and Push](https://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml)
+[![Trivy Scan](https://github.com/anthony-spruyt/container-images/actions/workflows/trivy-weekly-scan.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/trivy-weekly-scan.yaml)
 
 Monorepo for custom-built container images published to GitHub Container Registry.
 


### PR DESCRIPTION
## Summary

- Fix Trivy scan workflow to not fail when vulnerabilities found (set `exit-code: 0`)
- Add Trivy Scan badge to README
- Update Claude Code settings

## Changes

| File | Change |
|------|--------|
| `.github/workflows/trivy-weekly-scan.yaml` | Add `exit-code: 0` so workflow continues to create issues |
| `README.md` | Add Trivy Scan workflow badge |
| `.claude/settings.local.json` | Add `find` and `git checkout` permissions |

## Test plan

- [ ] Merge and re-trigger workflow
- [ ] Verify scan completes and creates issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)