### PR TITLE
fix(chrony): resolve user/group conflict with Alpine package

### DIFF
--- a/chrony/Dockerfile
+++ b/chrony/Dockerfile
@@ -13,11 +13,12 @@
 FROM alpine:3.21@sha256:5405e8f36ce1878720f71217d664aa3dea32e5e5df11acbf07fc78ef5661465b
 
 # Install chrony and timezone data
+# Note: chrony package creates its own user/group, we'll replace them with UID/GID 1000
 RUN apk add --no-cache chrony tzdata \
-    && rm -rf /var/cache/apk/*
-
-# Create non-root user with fixed UID/GID for Kubernetes compatibility
-RUN addgroup -g 1000 chrony \
+    && rm -rf /var/cache/apk/* \
+    && deluser chrony 2>/dev/null || true \
+    && delgroup chrony 2>/dev/null || true \
+    && addgroup -g 1000 chrony \
     && adduser -D -u 1000 -G chrony -h /var/lib/chrony chrony
 
 # Create required directories with correct ownership


### PR DESCRIPTION
## Summary
- Fix build failure caused by chrony Alpine package creating its own user/group
- Delete package-created chrony user/group before recreating with UID/GID 1000

## Root Cause
The Alpine chrony package (4.6.1-r0) runs a pre-install script that creates a `chrony` user and group. When we then tried to `addgroup -g 1000 chrony`, it failed with "group 'chrony' in use".

## Fix
Delete the package-created user/group, then recreate with our desired UID/GID 1000 for Kubernetes compatibility.

## Test plan
- [ ] CI build passes
- [ ] Container starts successfully
- [ ] Runs as UID 1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)