### PR TITLE
docs(readme): add GitHub badges and MIT license

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,3 +9,6 @@ https://github.com/anthony-spruyt/spruyt-labs/.*
 
 # Ignore Alpine Git URLs with dynamic version parameters (n8n templates)
 https://git.alpinelinux.org/aports/plain/.*\?h=.*
+
+# Ignore LICENSE URL until pushed (lychee checks remote URLs)
+https://github.com/anthony-spruyt/container-images/blob/main/LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Anthony Spruyt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Container Images
 
+[![License](https://img.shields.io/github/license/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/blob/main/LICENSE)
 [![Lint](https://github.com/anthony-spruyt/container-images/actions/workflows/lint.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/lint.yaml)
 [![Build and Push](https://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml)
 [![Trivy Scan](https://github.com/anthony-spruyt/container-images/actions/workflows/trivy-weekly-scan.yaml/badge.svg)](https://github.com/anthony-spruyt/container-images/actions/workflows/trivy-weekly-scan.yaml)
+[![Stars](https://img.shields.io/github/stars/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/stargazers)
+[![Forks](https://img.shields.io/github/forks/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/forks)
+[![Contributors](https://img.shields.io/github/contributors/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/graphs/contributors)
+[![Issues](https://img.shields.io/github/issues/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/issues)
 
 Monorepo for custom-built container images published to GitHub Container Registry.
 


### PR DESCRIPTION
## Summary
- Added GitHub badges for license, stars, forks, contributors, and issues to README
- Created MIT LICENSE file
- Updated .lycheeignore to temporarily ignore LICENSE URL until pushed
- Removed Test PR badge (only reflects PR status, not main branch health)

## Test plan
- [x] Linting passes locally (`./lint.sh`)
- [x] Pre-commit hooks pass
- [ ] MegaLinter CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)