### PR TITLE
docs(readme): align README and CLAUDE.md descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Monorepo for container images published to `ghcr.io/<owner>/<image>`. Images can be built from upstream repos or local Dockerfiles. The workflow builds, tests, scans, and pushes to GHCR.
+Container images built from upstream sources or custom Dockerfiles, published to `ghcr.io/<owner>/<image>` with automated security scanning and SLSA provenance.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Contributors](https://img.shields.io/github/contributors/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/graphs/contributors)
 [![Issues](https://img.shields.io/github/issues/anthony-spruyt/container-images)](https://github.com/anthony-spruyt/container-images/issues)
 
-Monorepo for custom-built container images published to GitHub Container Registry.
+Container images built from upstream sources or custom Dockerfiles, published to GitHub Container Registry with automated security scanning and SLSA provenance.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Align descriptions across all documentation to use consistent messaging:

> Container images built from upstream sources or custom Dockerfiles, with automated security scanning and SLSA provenance

**Updated:**
- README.md intro
- CLAUDE.md overview

**Already aligned:**
- GitHub repo description

🤖 Generated with [Claude Code](https://claude.com/claude-code)