### PR TITLE
fix(ci): exclude upstream-sourced images from Dependabot Docker scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,18 +25,6 @@ updates:
     schedule:
       interval: weekly
 
-  # Docker base images for firemerge
-  - package-ecosystem: "docker"
-    directory: "/firemerge"
-    schedule:
-      interval: weekly
-
-  # Docker base images for sungather
-  - package-ecosystem: "docker"
-    directory: "/sungather"
-    schedule:
-      interval: weekly
-
   # npm packages in devcontainer
   - package-ecosystem: "npm"
     directory: "/.devcontainer"

--- a/.github/scripts/generate-dependabot.sh
+++ b/.github/scripts/generate-dependabot.sh
@@ -46,7 +46,10 @@ for dir in "${IMAGE_DIRS[@]}"; do
         continue
     fi
 
-    cat >> "$DEPENDABOT_FILE" << EOF
+    # Only add Docker ecosystem entry if a Dockerfile exists
+    # Upstream-sourced images (no local Dockerfile) are skipped
+    if [[ -f "$REPO_ROOT/$dir/Dockerfile" ]]; then
+        cat >> "$DEPENDABOT_FILE" << EOF
   # Docker base images for $dir
   - package-ecosystem: "docker"
     directory: "/$dir"
@@ -54,6 +57,7 @@ for dir in "${IMAGE_DIRS[@]}"; do
       interval: weekly
 
 EOF
+    fi
 done
 
 # Add npm packages entry


### PR DESCRIPTION
Fixes Dependabot failures for upstream-sourced images (sungather and firemerge).

## Problem

Dependabot was failing on the main branch with error:
```
No Dockerfiles nor Kubernetes YAML found in /sungather
No Dockerfiles nor Kubernetes YAML found in /firemerge
```

Both sungather and firemerge are upstream-sourced images (built from upstream repositories) and don't have local Dockerfiles. The generate-dependabot.sh script was adding Docker ecosystem entries for ALL directories with metadata.yaml, regardless of whether they had local Dockerfiles.

## Solution

Modified `.github/scripts/generate-dependabot.sh` to check if a Dockerfile exists before adding Docker ecosystem entries:
- Only images with local Dockerfiles (like chrony) get Docker entries
- Upstream-sourced images (like sungather and firemerge) are skipped

## Changes

- Modified `.github/scripts/generate-dependabot.sh` to add Dockerfile existence check
- Regenerated `.github/dependabot.yml` with correct entries:
  - ✅ chrony (has Dockerfile)
  - ❌ sungather (upstream-sourced, no Dockerfile)
  - ❌ firemerge (upstream-sourced, no Dockerfile)

## Testing

After merge, Dependabot should successfully run on main without errors.