### PR TITLE
fix(ci): add explicit permissions to test workflow

### DIFF
--- a/.github/workflows/test-version-handling.yaml
+++ b/.github/workflows/test-version-handling.yaml
@@ -28,6 +28,9 @@ on:
         type: string
         default: "v0.5.3"
 
+permissions:
+  contents: read
+
 jobs:
   test-version-format:
     name: Test Version Format Handling


### PR DESCRIPTION
Resolves CodeQL security alert about missing workflow permissions.

## Changes

- Added explicit `permissions: contents: read` to [test-version-handling.yaml](../.github/workflows/test-version-handling.yaml#L31-L32)
- Follows principle of least privilege (test workflow only needs read access)
- Consistent with other read-only workflows ([lint.yaml](../.github/workflows/lint.yaml#L13-L14), [trivy-weekly-scan.yaml](../.github/workflows/trivy-weekly-scan.yaml#L11-L12))

## Security Alert

Resolves: https://github.com/anthony-spruyt/container-images/security/code-scanning/3

## Testing

- ✅ All MegaLinter checks pass locally
- ✅ Pre-commit hooks pass