### PR TITLE
docs(readme): add sungather to available images table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for development environment setup.
 | --------- | ----------------------------------------------------------------------- | ---------------------------------- |
 | chrony    | Local (no upstream)                                                     | `ghcr.io/anthony-spruyt/chrony`    |
 | firemerge | [anthony-spruyt/firemerge](https://github.com/anthony-spruyt/firemerge) | `ghcr.io/anthony-spruyt/firemerge` |
+| sungather | [bohdan-s/SunGather](https://github.com/bohdan-s/SunGather)             | `ghcr.io/anthony-spruyt/sungather` |
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Adds the missing sungather image to the Available Images table in README.

## Changes
- Added sungather row to the Available Images table
- Upstream: bohdan-s/SunGather
- Registry: ghcr.io/anthony-spruyt/sungather

🤖 Generated with [Claude Code](https://claude.com/claude-code)