### PR TITLE
fix(ci): use version (not tag) for upstream git checkout

### DIFF
--- a/.github/workflows/image-pipeline.yaml
+++ b/.github/workflows/image-pipeline.yaml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           repository: ${{ inputs.upstream || steps.metadata.outputs.upstream }}
-          ref: ${{ inputs.upstream-ref || steps.metadata.outputs.tag }}
+          ref: ${{ inputs.upstream-ref || steps.metadata.outputs.version }}
           path: upstream
 
       - name: Prepare build context


### PR DESCRIPTION
## Problem
Firemerge build fails when checking out upstream branch with slashes in the name:
```
fatal: couldn't find remote ref refs/heads/security-fix-cve-2025-64512-cve-2024-47874
```

## Root Cause
Line 110 in `image-pipeline.yaml` was using `steps.metadata.outputs.tag` (slashes converted to dashes) instead of `steps.metadata.outputs.version` (original format).

For version: `security/fix-cve-2025-64512-cve-2024-47874`
- **VERSION**: `security/fix-cve-2025-64512-cve-2024-47874` ✅ (git ref)
- **TAG**: `security-fix-cve-2025-64512-cve-2024-47874` ✅ (Docker tag)

Git needs the original format with slashes, Docker needs the sanitized format with dashes.

## Solution
Changed:
```yaml
ref: ${{ inputs.upstream-ref || steps.metadata.outputs.tag }}
```
To:
```yaml
ref: ${{ inputs.upstream-ref || steps.metadata.outputs.version }}
```

## Testing
After merge, firemerge build should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)