### PR TITLE
fix(chrony): align version with Alpine package (4.8)

### DIFF
--- a/chrony/metadata.yaml
+++ b/chrony/metadata.yaml
@@ -2,4 +2,4 @@
 # Chrony - Minimal NTP server with zero capabilities
 # Custom image for Kubernetes deployments requiring least privilege
 
-version: "0.1.1"
+version: "4.8"


### PR DESCRIPTION
Updates chrony version from custom 0.1.1 to Alpine package version 4.8 to match n8n automation expectations.