### PR TITLE
fix(devcontainer): prevent SSH agent mount failures after WSL reboot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "runArgs": ["--env-file", "${localEnv:HOME}/.secrets/.env"],
   "mounts": [
-    "source=${localEnv:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",
+    "source=${localEnv:HOME}/.ssh/agent.sock,target=/ssh-agent,type=bind",
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
   ],
@@ -17,6 +17,7 @@
     "ghcr.io/devcontainers/features/node": {},
     "ghcr.io/devcontainers/features/python": {}
   },
+  "initializeCommand": "bash -c 'if [ ! -S \"$HOME/.ssh/agent.sock\" ]; then echo \"❌ ERROR: SSH agent socket not found at $HOME/.ssh/agent.sock\"; echo \"📖 Please see DEVELOPMENT.md SSH Agent Setup for configuration instructions.\"; exit 1; fi'",
   "postCreateCommand": "bash -lc \"cd ${containerWorkspaceFolder} && ./.devcontainer/post-create.sh\"",
   "customizations": {
     "vscode": {

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,12 +6,39 @@ This repository uses a VS Code devcontainer for a consistent development experie
 
 - [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) or Docker Engine
-- SSH agent running with your keys loaded (for git operations)
+- SSH agent running with keys loaded (see [SSH Agent Setup](#ssh-agent-setup))
 - GitHub token in `~/.secrets/.env` (for GitHub CLI operations)
+
+## Host Directory Structure
+
+The devcontainer expects these directories on your host machine:
+
+```text
+~/.secrets/
+├── .env                    # Environment variables (loaded via --env-file)
+└── ...                     # Other secrets as needed
+
+~/.claude/                  # Claude Code settings and memory
+```
+
+Create the required structure:
+
+```bash
+mkdir -p ~/.claude
+touch ~/.secrets/.env
+```
+
+The `.env` file sets environment variables and paths to secrets:
+
+```bash
+GH_TOKEN=<github-token>
+CONTEXT7_API_KEY=<context7-key>
+```
 
 ## SSH Agent Setup
 
-The devcontainer uses SSH agent forwarding for secure git authentication. Your private keys stay on the host.
+The devcontainer uses SSH agent forwarding via socket mount. Your private keys stay on
+the host and are never copied into the container.
 
 The devcontainer also mounts your `~/.gitconfig` (read-only) for git identity and commit signing. To enable SSH commit signing on your host:
 
@@ -34,9 +61,16 @@ For passphrase-protected keys, use `keychain` to persist across sessions:
 # Install: sudo apt install keychain
 # Add to ~/.bashrc or ~/.zshrc:
 eval "$(keychain --eval --agents ssh id_ed25519)"
+
+# Create stable symlink for devcontainer (required for reboot persistence)
+export SSH_AUTH_SOCK_LINK="$HOME/.ssh/agent.sock"
+if [ -S "$SSH_AUTH_SOCK" ]; then
+  ln -sf "$SSH_AUTH_SOCK" "$SSH_AUTH_SOCK_LINK"
+  export SSH_AUTH_SOCK="$SSH_AUTH_SOCK_LINK"
+fi
 ```
 
-`keychain` prompts for your passphrase once per reboot and reuses the agent across terminals.
+`keychain` prompts for your passphrase once per reboot and reuses the agent across terminals. The symlink ensures the devcontainer can mount a consistent SSH agent path across reboots.
 
 **macOS:**
 
@@ -54,6 +88,24 @@ ssh-add ~/.ssh/id_ed25519
 ```
 
 Or enable the OpenSSH Authentication Agent service in Windows Services.
+
+## Troubleshooting
+
+### Devcontainer fails to start after reboot with mount error
+
+**Error**: `error mounting "..." to rootfs at "/ssh-agent": not a directory`
+
+**Cause**: The SSH agent socket path changed after reboot, but your devcontainer was created with the old path.
+
+**Solution**:
+
+1. Verify the fixed symlink is configured in your `~/.bashrc` (see keychain setup above)
+2. Restart your terminal or run: `source ~/.bashrc`
+3. Verify the symlink exists: `ls -la ~/.ssh/agent.sock`
+4. **Rebuild the devcontainer one final time**: Command Palette → "Dev Containers: Rebuild Container"
+5. After this rebuild, reboots will no longer require rebuilds
+
+If the symlink is missing or broken after reboot, ensure the keychain configuration is in `~/.bashrc` (not just set in the current terminal session).
 
 ## GitHub CLI Setup
 


### PR DESCRIPTION
## Summary

Fixes the recurring issue where the devcontainer fails to start after WSL reboot with SSH agent mount errors.

## Problem

After WSL reboot, keychain creates a new SSH agent socket with a different path. The devcontainer was created with the old socket path mounted, causing mount failures:

```
error mounting "..." to rootfs at "/ssh-agent": not a directory
```

Users had to rebuild the container after every reboot.

## Solution

Use a fixed symlink path (`~/.ssh/agent.sock`) that always points to keychain's current socket. The devcontainer mounts this stable path, which survives reboots.

## Changes

- **devcontainer.json**: Mount `~/.ssh/agent.sock` instead of `${localEnv:SSH_AUTH_SOCK}`
- **devcontainer.json**: Add `initializeCommand` to validate socket exists before container creation
- **DEVELOPMENT.md**: Document keychain symlink configuration
- **DEVELOPMENT.md**: Add troubleshooting section for mount errors
- **DEVELOPMENT.md**: Improve host directory structure documentation

## Migration Steps

Users need to:
1. Update `~/.bashrc` with the symlink configuration (see updated DEVELOPMENT.md)
2. Run `source ~/.bashrc`
3. Rebuild devcontainer one final time
4. After that, reboots won't require rebuilds

## Testing

- ✅ Tested with existing keychain setup
- ✅ Symlink verified working: `~/.ssh/agent.sock -> /tmp/ssh-pNY4YYJMKgO2/agent.465`
- ✅ Devcontainer starts successfully with new mount configuration
- ✅ All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)