### PR TITLE
fix(ci): detect immutable tags and fix n8n nightly dispatch

### DIFF
--- a/.github/workflows/image-pipeline.yaml
+++ b/.github/workflows/image-pipeline.yaml
@@ -116,13 +116,30 @@ jobs:
           fi
 
           RELEASE_TAG="${IMAGE_NAME}-${TAG}"
+
+          # Check if release exists (exact match)
           if gh release view "$RELEASE_TAG" &>/dev/null; then
             echo "::notice::Release $RELEASE_TAG already exists, skipping build"
             echo "should-build=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Release $RELEASE_TAG does not exist, will build"
-            echo "should-build=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Check for releases with -rN suffix (immutable tag retries)
+          if gh release list --limit 100 2>/dev/null | grep -qE "^${RELEASE_TAG}-r[0-9]+[[:space:]]"; then
+            echo "::notice::Release with retry suffix exists for $RELEASE_TAG, skipping build"
+            echo "should-build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check if git tag exists (indicates prior release, even if deleted)
+          if git ls-remote --tags origin "refs/tags/${RELEASE_TAG}" 2>/dev/null | grep -q .; then
+            echo "::notice::Git tag $RELEASE_TAG exists (immutable), skipping build"
+            echo "should-build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::notice::Release $RELEASE_TAG does not exist, will build"
+          echo "should-build=true" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,17 +44,19 @@ Create `<image-name>/test.sh` - runs after build, before Trivy scan. See `chrony
 
 ### Optional: Add n8n Release Watcher
 
-When creating n8n workflows that track versions using static data:
+The existing n8n templates (`chrony/n8n-release-watcher.json`, `firemerge/n8n-release-watcher.json`, `sungather/n8n-release-watcher.json`) check for new upstream versions and trigger builds automatically.
 
-- **Variable pattern:** `lastVersion_{image_name}` (lowercase image name)
-- **Examples:**
-  - Firemerge: `staticData.lastVersion_firemerge`
-  - Chrony: `staticData.lastVersion_chrony`
-  - New image: `staticData.lastVersion_{imagename}`
+**How version checking works:**
 
-This prevents variable name collisions when multiple workflows run on the same n8n instance.
+- Templates fetch existing releases from `api.github.com/repos/{owner}/container-images/releases`
+- Compare upstream version against existing release tags (pattern: `{image}-{version}` or `{image}-{version}-rN`)
+- Only dispatch build if no matching release exists
 
-When copying an existing workflow template, update all `staticData.lastVersion` references to include the image name.
+When copying a template for a new image, update:
+
+- The upstream repository URL (tags endpoint)
+- The image name in the release tag pattern
+- The image name in the workflow dispatch body
 
 ## Build Triggers
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Create an n8n workflow to automatically trigger builds when upstream repos relea
    GET https://api.github.com/repos/lvu/firemerge/tags?per_page=1
    ```
 
-3. **Compare Version** - Check if version differs from last triggered build (store in n8n static data or external DB)
+3. **Compare Version** - Check if release already exists via GitHub releases API (pattern: `{image}-{version}` or `{image}-{version}-rN`)
 
 4. **Trigger Build** - HTTP Request (only if new version):
 

--- a/chrony/n8n-release-watcher.json
+++ b/chrony/n8n-release-watcher.json
@@ -64,13 +64,30 @@
     },
     {
       "parameters": {
-        "jsCode": "// Get workflow static data to track last processed version\nconst staticData = $getWorkflowStaticData('global');\n\n// Get Alpine version from earlier node\nconst alpineVersion = $('Parse Alpine Version').item.json.alpineVersion;\n\n// Parse chrony version from APKBUILD\nconst apkbuild = $input.first().json.data;\nconst pkgverMatch = apkbuild.match(/pkgver=([0-9.]+)/);\nconst pkgrelMatch = apkbuild.match(/pkgrel=([0-9]+)/);\n\nif (!pkgverMatch) {\n  return [{ json: { isNew: false, version: null, error: 'Could not parse pkgver from APKBUILD' } }];\n}\n\nconst pkgver = pkgverMatch[1];\nconst pkgrel = pkgrelMatch ? pkgrelMatch[1] : '0';\nconst version = `${pkgver}-r${pkgrel}`;\n\n// Check if this is a new version\nconst lastVersion = staticData.lastVersion_chrony || null;\nconst isNew = lastVersion !== version;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    pkgver: pkgver,\n    pkgrel: pkgrel,\n    lastVersion: lastVersion,\n    alpineVersion: alpineVersion\n  }\n}];"
+        "url": "https://api.github.com/repos/anthony-spruyt/container-images/releases",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "get-releases",
+      "name": "Get GitHub Releases",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [880, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get Alpine version from earlier node\nconst alpineVersion = $('Parse Alpine Version').item.json.alpineVersion;\n\n// Parse chrony version from APKBUILD\nconst apkbuild = $('Get Alpine APKBUILD').item.json.data;\nconst pkgverMatch = apkbuild.match(/pkgver=([0-9.]+)/);\nconst pkgrelMatch = apkbuild.match(/pkgrel=([0-9]+)/);\n\nif (!pkgverMatch) {\n  return [{ json: { isNew: false, version: null, error: 'Could not parse pkgver from APKBUILD' } }];\n}\n\nconst pkgver = pkgverMatch[1];\nconst pkgrel = pkgrelMatch ? pkgrelMatch[1] : '0';\nconst version = `${pkgver}-r${pkgrel}`;\n\n// Check GitHub releases to see if this version was already built\n// Release tag format: chrony-{version} or chrony-{version}-rN (for retries)\nconst releases = $input.first().json;\nconst releasePattern = new RegExp(`^chrony-${pkgver}(-r[0-9]+)?$`);\nconst existingRelease = Array.isArray(releases) \n  ? releases.find(r => releasePattern.test(r.tag_name))\n  : null;\n\nconst isNew = !existingRelease;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: pkgver,\n    fullVersion: version,\n    pkgver: pkgver,\n    pkgrel: pkgrel,\n    existingRelease: existingRelease ? existingRelease.tag_name : null,\n    alpineVersion: alpineVersion\n  }\n}];"
       },
       "id": "check-version",
       "name": "Check New Version",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [880, 0]
+      "position": [1100, 0]
     },
     {
       "parameters": {
@@ -99,7 +116,17 @@
       "name": "Is New Version?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
-      "position": [1100, 0]
+      "position": [1320, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Update static data with the new version (kept for backwards compatibility)\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.fullVersion;\nstaticData.lastVersion_chrony = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
+      },
+      "id": "update-state",
+      "name": "Update State",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1540, -100]
     },
     {
       "parameters": {
@@ -118,14 +145,14 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"chrony\",\n    \"version\": \"{{ $json.pkgver }}\",\n    \"dry_run\": \"false\"\n  }\n}",
+        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"chrony\",\n    \"version\": \"{{ $('Check New Version').item.json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
         "options": {}
       },
       "id": "trigger-build",
       "name": "Trigger Build Workflow",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1320, -100],
+      "position": [1760, -100],
       "credentials": {
         "httpHeaderAuth": {
           "id": "CONFIGURE_ME",
@@ -137,32 +164,22 @@
       "parameters": {
         "fromEmail": "noreply@example.com",
         "toEmail": "CONFIGURE_ME@example.com",
-        "subject": "=Chrony {{ $('Check New Version').item.json.version }} - Build triggered",
+        "subject": "=Chrony {{ $('Check New Version').item.json.fullVersion }} - Build triggered",
         "emailType": "text",
-        "message": "=A new Chrony package version has been detected in Alpine Linux and a container build has been triggered.\n\nPackage Version: {{ $('Check New Version').item.json.version }}\nPrevious Version: {{ $('Check New Version').item.json.lastVersion || 'None (first run)' }}\nAlpine Version: {{ $('Check New Version').item.json.alpineVersion }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nAlpine Package:\nhttps://pkgs.alpinelinux.org/package/v{{ $('Check New Version').item.json.alpineVersion }}/main/x86_64/chrony\n\nUpstream Project:\nhttps://chrony-project.org/",
+        "message": "=A new Chrony package version has been detected in Alpine Linux and a container build has been triggered.\n\nPackage Version: {{ $('Check New Version').item.json.fullVersion }}\nExisting Release: {{ $('Check New Version').item.json.existingRelease || 'None' }}\nAlpine Version: {{ $('Check New Version').item.json.alpineVersion }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nAlpine Package:\nhttps://pkgs.alpinelinux.org/package/v{{ $('Check New Version').item.json.alpineVersion }}/main/x86_64/chrony\n\nUpstream Project:\nhttps://chrony-project.org/",
         "options": {}
       },
       "id": "send-email",
       "name": "Send Notification",
       "type": "n8n-nodes-base.emailSend",
       "typeVersion": 2.1,
-      "position": [1540, -100],
+      "position": [1980, -100],
       "credentials": {
         "smtp": {
           "id": "CONFIGURE_ME",
           "name": "SMTP"
         }
       }
-    },
-    {
-      "parameters": {
-        "jsCode": "// Update static data with the new version\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion_chrony = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
-      },
-      "id": "update-state",
-      "name": "Update State",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [1760, -100]
     }
   ],
   "connections": {
@@ -203,6 +220,17 @@
       "main": [
         [
           {
+            "node": "Get GitHub Releases",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get GitHub Releases": {
+      "main": [
+        [
+          {
             "node": "Check New Version",
             "type": "main",
             "index": 0
@@ -225,7 +253,7 @@
       "main": [
         [
           {
-            "node": "Trigger Build Workflow",
+            "node": "Update State",
             "type": "main",
             "index": 0
           }
@@ -233,22 +261,22 @@
         []
       ]
     },
-    "Trigger Build Workflow": {
+    "Update State": {
       "main": [
         [
           {
-            "node": "Send Notification",
+            "node": "Trigger Build Workflow",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send Notification": {
+    "Trigger Build Workflow": {
       "main": [
         [
           {
-            "node": "Update State",
+            "node": "Send Notification",
             "type": "main",
             "index": 0
           }

--- a/firemerge/n8n-release-watcher.json
+++ b/firemerge/n8n-release-watcher.json
@@ -31,13 +31,30 @@
     },
     {
       "parameters": {
-        "jsCode": "// Get workflow static data to track last processed version\nconst staticData = $getWorkflowStaticData('global');\n\n// Get the latest tag from the GitHub API response\n// n8n splits the array response into separate items, so first item = latest tag\nconst items = $input.all();\nif (!items || items.length === 0 || !items[0].json) {\n  return [{ json: { isNew: false, version: null, error: 'No tags found' } }];\n}\n\n// First item is the latest tag (GitHub returns tags sorted by creation date desc)\nconst latestTag = items[0].json;\nif (!latestTag.name) {\n  return [{ json: { isNew: false, version: null, error: 'Invalid tag data' } }];\n}\n\n// Keep version as-is from upstream tag (needed for git checkout)\nconst version = latestTag.name;\n\n// Check if this is a new version\nconst lastVersion = staticData.lastVersion_firemerge || null;\nconst isNew = lastVersion !== version;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    lastVersion: lastVersion,\n    commitSha: latestTag.commit?.sha || null\n  }\n}];"
+        "url": "https://api.github.com/repos/anthony-spruyt/container-images/releases",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "get-releases",
+      "name": "Get GitHub Releases",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [440, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get the latest tag from the upstream GitHub API response\n// Access tags from earlier node since releases are now the input\nconst tags = $('Get GitHub Tags').all();\nif (!tags || tags.length === 0 || !tags[0].json) {\n  return [{ json: { isNew: false, version: null, error: 'No tags found' } }];\n}\n\n// First item is the latest tag (GitHub returns tags sorted by creation date desc)\nconst latestTag = tags[0].json;\nif (!latestTag.name) {\n  return [{ json: { isNew: false, version: null, error: 'Invalid tag data' } }];\n}\n\n// Keep version as-is from upstream tag (needed for git checkout)\nconst version = latestTag.name;\n\n// Check GitHub releases to see if this version was already built\n// Release tag format: firemerge-{version} or firemerge-{version}-rN (for retries)\nconst releases = $input.first().json;\nconst releasePattern = new RegExp(`^firemerge-${version.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}(-r[0-9]+)?$`);\nconst existingRelease = Array.isArray(releases) \n  ? releases.find(r => releasePattern.test(r.tag_name))\n  : null;\n\nconst isNew = !existingRelease;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    existingRelease: existingRelease ? existingRelease.tag_name : null,\n    commitSha: latestTag.commit?.sha || null\n  }\n}];"
       },
       "id": "check-version",
       "name": "Check New Version",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [440, 0]
+      "position": [660, 0]
     },
     {
       "parameters": {
@@ -66,7 +83,17 @@
       "name": "Is New Version?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
-      "position": [660, 0]
+      "position": [880, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Update static data with the new version (kept for backwards compatibility)\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion_firemerge = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
+      },
+      "id": "update-state",
+      "name": "Update State",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, -100]
     },
     {
       "parameters": {
@@ -85,14 +112,14 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"firemerge\",\n    \"version\": \"{{ $json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
+        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"firemerge\",\n    \"version\": \"{{ $('Check New Version').item.json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
         "options": {}
       },
       "id": "trigger-build",
       "name": "Trigger Build Workflow",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [880, -100],
+      "position": [1320, -100],
       "credentials": {
         "httpHeaderAuth": {
           "id": "CONFIGURE_ME",
@@ -106,30 +133,20 @@
         "toEmail": "CONFIGURE_ME@example.com",
         "subject": "=Firemerge {{ $('Check New Version').item.json.version }} - Build triggered",
         "emailType": "text",
-        "message": "=A new Firemerge release has been detected and a container build has been triggered.\n\nVersion: {{ $('Check New Version').item.json.version }}\nPrevious Version: {{ $('Check New Version').item.json.lastVersion || 'None (first run)' }}\nCommit: {{ $('Check New Version').item.json.commitSha || 'N/A' }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nUpstream Release:\nhttps://github.com/lvu/firemerge/releases/tag/{{ $('Check New Version').item.json.version }}",
+        "message": "=A new Firemerge release has been detected and a container build has been triggered.\n\nVersion: {{ $('Check New Version').item.json.version }}\nExisting Release: {{ $('Check New Version').item.json.existingRelease || 'None' }}\nCommit: {{ $('Check New Version').item.json.commitSha || 'N/A' }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nUpstream Release:\nhttps://github.com/lvu/firemerge/releases/tag/{{ $('Check New Version').item.json.version }}",
         "options": {}
       },
       "id": "send-email",
       "name": "Send Notification",
       "type": "n8n-nodes-base.emailSend",
       "typeVersion": 2.1,
-      "position": [1100, -100],
+      "position": [1540, -100],
       "credentials": {
         "smtp": {
           "id": "CONFIGURE_ME",
           "name": "SMTP"
         }
       }
-    },
-    {
-      "parameters": {
-        "jsCode": "// Update static data with the new version\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion_firemerge = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
-      },
-      "id": "update-state",
-      "name": "Update State",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [1320, -100]
     }
   ],
   "connections": {
@@ -145,6 +162,17 @@
       ]
     },
     "Get GitHub Tags": {
+      "main": [
+        [
+          {
+            "node": "Get GitHub Releases",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get GitHub Releases": {
       "main": [
         [
           {
@@ -170,7 +198,7 @@
       "main": [
         [
           {
-            "node": "Trigger Build Workflow",
+            "node": "Update State",
             "type": "main",
             "index": 0
           }
@@ -178,22 +206,22 @@
         []
       ]
     },
-    "Trigger Build Workflow": {
+    "Update State": {
       "main": [
         [
           {
-            "node": "Send Notification",
+            "node": "Trigger Build Workflow",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send Notification": {
+    "Trigger Build Workflow": {
       "main": [
         [
           {
-            "node": "Update State",
+            "node": "Send Notification",
             "type": "main",
             "index": 0
           }

--- a/sungather/n8n-release-watcher.json
+++ b/sungather/n8n-release-watcher.json
@@ -31,13 +31,30 @@
     },
     {
       "parameters": {
-        "jsCode": "// Get workflow static data to track last processed version\nconst staticData = $getWorkflowStaticData('global');\n\n// Get the latest tag from the GitHub API response\n// n8n splits the array response into separate items, so first item = latest tag\nconst items = $input.all();\nif (!items || items.length === 0 || !items[0].json) {\n  return [{ json: { isNew: false, version: null, error: 'No tags found' } }];\n}\n\n// First item is the latest tag (GitHub returns tags sorted by creation date desc)\nconst latestTag = items[0].json;\nif (!latestTag.name) {\n  return [{ json: { isNew: false, version: null, error: 'Invalid tag data' } }];\n}\n\n// Keep version as-is from upstream tag (needed for git checkout)\nconst version = latestTag.name;\n\n// Check if this is a new version\nconst lastVersion = staticData.lastVersion_sungather || null;\nconst isNew = lastVersion !== version;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    lastVersion: lastVersion,\n    commitSha: latestTag.commit?.sha || null\n  }\n}];"
+        "url": "https://api.github.com/repos/anthony-spruyt/container-images/releases",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "get-releases",
+      "name": "Get GitHub Releases",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [440, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get the latest tag from the upstream GitHub API response\n// Access tags from earlier node since releases are now the input\nconst tags = $('Get GitHub Tags').all();\nif (!tags || tags.length === 0 || !tags[0].json) {\n  return [{ json: { isNew: false, version: null, error: 'No tags found' } }];\n}\n\n// First item is the latest tag (GitHub returns tags sorted by creation date desc)\nconst latestTag = tags[0].json;\nif (!latestTag.name) {\n  return [{ json: { isNew: false, version: null, error: 'Invalid tag data' } }];\n}\n\n// Keep version as-is from upstream tag (needed for git checkout)\nconst version = latestTag.name;\n\n// Check GitHub releases to see if this version was already built\n// Release tag format: sungather-{version} or sungather-{version}-rN (for retries)\nconst releases = $input.first().json;\nconst releasePattern = new RegExp(`^sungather-${version.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}(-r[0-9]+)?$`);\nconst existingRelease = Array.isArray(releases) \n  ? releases.find(r => releasePattern.test(r.tag_name))\n  : null;\n\nconst isNew = !existingRelease;\n\nreturn [{\n  json: {\n    isNew: isNew,\n    version: version,\n    existingRelease: existingRelease ? existingRelease.tag_name : null,\n    commitSha: latestTag.commit?.sha || null\n  }\n}];"
       },
       "id": "check-version",
       "name": "Check New Version",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [440, 0]
+      "position": [660, 0]
     },
     {
       "parameters": {
@@ -66,7 +83,17 @@
       "name": "Is New Version?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
-      "position": [660, 0]
+      "position": [880, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Update static data with the new version (kept for backwards compatibility)\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion_sungather = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
+      },
+      "id": "update-state",
+      "name": "Update State",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, -100]
     },
     {
       "parameters": {
@@ -85,14 +112,14 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"sungather\",\n    \"version\": \"{{ $json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
+        "jsonBody": "={\n  \"ref\": \"main\",\n  \"inputs\": {\n    \"image\": \"sungather\",\n    \"version\": \"{{ $('Check New Version').item.json.version }}\",\n    \"dry_run\": \"false\"\n  }\n}",
         "options": {}
       },
       "id": "trigger-build",
       "name": "Trigger Build Workflow",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [880, -100],
+      "position": [1320, -100],
       "credentials": {
         "httpHeaderAuth": {
           "id": "CONFIGURE_ME",
@@ -106,30 +133,20 @@
         "toEmail": "CONFIGURE_ME@example.com",
         "subject": "=SunGather {{ $('Check New Version').item.json.version }} - Build triggered",
         "emailType": "text",
-        "message": "=A new SunGather release has been detected and a container build has been triggered.\n\nVersion: {{ $('Check New Version').item.json.version }}\nPrevious Version: {{ $('Check New Version').item.json.lastVersion || 'None (first run)' }}\nCommit: {{ $('Check New Version').item.json.commitSha || 'N/A' }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nUpstream Release:\nhttps://github.com/bohdan-s/SunGather/releases/tag/{{ $('Check New Version').item.json.version }}",
+        "message": "=A new SunGather release has been detected and a container build has been triggered.\n\nVersion: {{ $('Check New Version').item.json.version }}\nExisting Release: {{ $('Check New Version').item.json.existingRelease || 'None' }}\nCommit: {{ $('Check New Version').item.json.commitSha || 'N/A' }}\n\nGitHub Actions:\nhttps://github.com/anthony-spruyt/container-images/actions/workflows/build-and-push.yaml\n\nUpstream Release:\nhttps://github.com/bohdan-s/SunGather/releases/tag/{{ $('Check New Version').item.json.version }}",
         "options": {}
       },
       "id": "send-email",
       "name": "Send Notification",
       "type": "n8n-nodes-base.emailSend",
       "typeVersion": 2.1,
-      "position": [1100, -100],
+      "position": [1540, -100],
       "credentials": {
         "smtp": {
           "id": "CONFIGURE_ME",
           "name": "SMTP"
         }
       }
-    },
-    {
-      "parameters": {
-        "jsCode": "// Update static data with the new version\nconst staticData = $getWorkflowStaticData('global');\nconst version = $('Check New Version').item.json.version;\nstaticData.lastVersion_sungather = version;\n\nreturn [{\n  json: {\n    success: true,\n    version: version,\n    message: `Updated last version to ${version}`\n  }\n}];"
-      },
-      "id": "update-state",
-      "name": "Update State",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [1320, -100]
     }
   ],
   "connections": {
@@ -145,6 +162,17 @@
       ]
     },
     "Get GitHub Tags": {
+      "main": [
+        [
+          {
+            "node": "Get GitHub Releases",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get GitHub Releases": {
       "main": [
         [
           {
@@ -170,7 +198,7 @@
       "main": [
         [
           {
-            "node": "Trigger Build Workflow",
+            "node": "Update State",
             "type": "main",
             "index": 0
           }
@@ -178,22 +206,22 @@
         []
       ]
     },
-    "Trigger Build Workflow": {
+    "Update State": {
       "main": [
         [
           {
-            "node": "Send Notification",
+            "node": "Trigger Build Workflow",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send Notification": {
+    "Trigger Build Workflow": {
       "main": [
         [
           {
-            "node": "Update State",
+            "node": "Send Notification",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary

- Add git tag existence check to `check-release` step to detect immutable tags from deleted releases, preventing repeated build attempts
- Add release pattern matching for `-rN` suffix (retry releases)
- Update n8n templates to check GitHub releases API instead of relying on staticData persistence
- Reorder n8n workflow: Update State now runs before Trigger Build
- Update documentation to reflect new version checking approach

## Problem

1. **Immutable tag issue**: When a release is deleted but the git tag is immutable, `check-release` looked for `sungather-0.5.2` (not found), triggered build, but `create-release.sh` created `sungather-0.5.2-r1`. Next night, same cycle repeated creating `-r2`, `-r3`, etc.

2. **n8n nightly dispatch**: All release watchers dispatched builds every night even when versions hadn't changed. The staticData wasn't persisting between workflow executions.

## Solution

### Fix 1: check-release improvements
- Check for existing release (exact match)
- Check for releases with `-rN` suffix pattern
- Check if git tag exists (indicates prior release, even if deleted)

### Fix 2: n8n templates
- Added "Get GitHub Releases" node to fetch existing container-images releases
- Updated "Check New Version" to compare against releases API instead of staticData
- Pattern matches `{image}-{version}` or `{image}-{version}-rN`

## Test plan

- [ ] Verify linting passes (MegaLinter)
- [ ] Verify test-version-handling workflow passes
- [ ] After merge: trigger build for existing release - should skip with "Git tag exists" message
- [ ] After merge: import updated n8n templates and verify they don't dispatch for existing releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)