### PR TITLE
fix(ci): correct check-release pattern matching for -rN suffix

### DIFF
--- a/.github/workflows/image-pipeline.yaml
+++ b/.github/workflows/image-pipeline.yaml
@@ -125,15 +125,16 @@ jobs:
           fi
 
           # Check for releases with -rN suffix (immutable tag retries)
-          if gh release list --limit 100 2>/dev/null | grep -qE "^${RELEASE_TAG}-r[0-9]+[[:space:]]"; then
-            echo "::notice::Release with retry suffix exists for $RELEASE_TAG, skipping build"
+          # gh release list format: TITLE<tab>TAG<tab>DATE - search for tag anywhere in line
+          if gh release list --limit 100 2>/dev/null | grep -qE "[[:space:]]${RELEASE_TAG}(-r[0-9]+)?[[:space:]]"; then
+            echo "::notice::Release matching $RELEASE_TAG found, skipping build"
             echo "should-build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Check if git tag exists (indicates prior release, even if deleted)
-          if git ls-remote --tags origin "refs/tags/${RELEASE_TAG}" 2>/dev/null | grep -q .; then
-            echo "::notice::Git tag $RELEASE_TAG exists (immutable), skipping build"
+          # Check if git tag exists (with or without -rN suffix)
+          if git ls-remote --tags origin "refs/tags/${RELEASE_TAG}*" 2>/dev/null | grep -q .; then
+            echo "::notice::Git tag matching $RELEASE_TAG exists (immutable), skipping build"
             echo "should-build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Fixes bug in check-release step where existing releases with `-rN` suffix weren't being detected.

## Problem

When checking for `sungather-v0.5.3`, the patterns failed to match the actual release `sungather-v0.5.3-r4`:

1. **grep pattern bug**: `gh release list` output format is `TITLE<tab>TAG<tab>DATE`. The `^` anchor expected tag at line start, but it's in the middle column.

2. **git ls-remote bug**: Used exact match `refs/tags/sungather-v0.5.3` which doesn't match `refs/tags/sungather-v0.5.3-r4`.

## Fix

1. Changed grep from `^${RELEASE_TAG}-r[0-9]+` to `[[:space:]]${RELEASE_TAG}(-r[0-9]+)?[[:space:]]`
2. Changed git ls-remote to use wildcard: `refs/tags/${RELEASE_TAG}*`

## Test plan

- [x] Verified patterns match locally against actual releases
- [ ] CI checks pass
- [ ] After merge: n8n dispatch should be skipped for existing sungather-v0.5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)