### PR TITLE
chore: update dependabot to daily and fix safe-chain PATH export

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,8 +16,12 @@ echo "Setting up safe-chain..."
 safe-chain setup        # Shell aliases for interactive terminals
 safe-chain setup-ci     # Executable shims for scripts/CI
 
+# Add safe-chain shims to PATH for all subsequent commands
+# This ensures pre-commit and other tools use protected pip/npm
+export PATH="$HOME/.safe-chain/shims:$PATH"
+
 echo "Installing remaining npm tools (now protected by safe-chain)..."
-"$HOME/.safe-chain/shims/npm" install -g "@anthropic-ai/claude-code@$(node -p "require('./package.json').dependencies['@anthropic-ai/claude-code']")"
+npm install -g "@anthropic-ai/claude-code@$(node -p "require('./package.json').dependencies['@anthropic-ai/claude-code']")" --safe-chain-skip-minimum-package-age
 
 echo "Installing pre-commit hooks..."
 pre-commit install --install-hooks

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,13 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
 
   # GitHub Actions (SHA-pinned)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       actions:
         patterns:
@@ -23,10 +23,10 @@ updates:
   - package-ecosystem: "docker"
     directory: "/chrony"
     schedule:
-      interval: weekly
+      interval: daily
 
   # npm packages in devcontainer
   - package-ecosystem: "npm"
     directory: "/.devcontainer"
     schedule:
-      interval: weekly
+      interval: daily

--- a/.github/scripts/generate-dependabot.sh
+++ b/.github/scripts/generate-dependabot.sh
@@ -25,13 +25,13 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
 
   # GitHub Actions (SHA-pinned)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       actions:
         patterns:
@@ -54,7 +54,7 @@ for dir in "${IMAGE_DIRS[@]}"; do
   - package-ecosystem: "docker"
     directory: "/$dir"
     schedule:
-      interval: weekly
+      interval: daily
 
 EOF
     fi
@@ -66,7 +66,7 @@ cat >> "$DEPENDABOT_FILE" << 'EOF'
   - package-ecosystem: "npm"
     directory: "/.devcontainer"
     schedule:
-      interval: weekly
+      interval: daily
 EOF
 
 echo "Generated $DEPENDABOT_FILE with entries for: ${IMAGE_DIRS[*]}"


### PR DESCRIPTION
## Summary
- Change dependabot update interval from weekly to daily for all ecosystems (devcontainers, github-actions, docker, npm)
- Fix safe-chain setup by exporting PATH with shims directory before npm install
- Add `--safe-chain-skip-minimum-package-age` flag for claude-code installation

## Test plan
- [ ] Verify dependabot picks up the new daily schedule
- [ ] Rebuild devcontainer to confirm safe-chain PATH works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)