### PR TITLE
fix(gastown-dev): suppress docker-init warnings in CLI tools test

### DIFF
--- a/gastown-dev/test.sh
+++ b/gastown-dev/test.sh
@@ -4,9 +4,9 @@ IMAGE_REF="$1"
 
 echo "Testing gastown-dev image..."
 
-# Test CLI tools are available
+# Test CLI tools are available (skip entrypoint since we don't need Docker here)
 echo "=== Testing CLI Tools ==="
-docker run --rm "$IMAGE_REF" bash -c '
+docker run --rm --entrypoint "" "$IMAGE_REF" bash -c '
   echo "=== Devcontainer Features ===" &&
   node --version &&
   python3 --version &&


### PR DESCRIPTION
## Summary
- Skip the entrypoint for the CLI tools test using `--entrypoint ""`
- This prevents docker-init.sh from attempting to start dockerd without `--privileged`
- Eliminates the many mount/cgroup warnings in CI output

## Problem
The CLI tools test was running with the docker-init.sh entrypoint which tries to start Docker daemon. Without `--privileged`, this generates many warnings about permission denied, read-only filesystem, etc.

## Test plan
- [ ] CI runs without the mount/cgroup warnings in CLI tools test
- [ ] Docker-in-Docker test still works (uses entrypoint with `--privileged`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)