### PR TITLE
fix(workflows): add repo context to gh CLI commands

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
-          gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
+          gh pr merge --repo "${{ github.repository }}" --auto --squash --delete-branch "$PR_NUMBER"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes the "not a git repository" error in the dependabot automerge workflow.

## Details
- Adds --repo flag to gh CLI commands so they work without a git checkout
- The workflow runs in a clean environment without checking out the repository
- This fix allows gh CLI to know which repository to operate on

## Testing
Will test on PR #112 after this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)