### PR TITLE
fix(trivy): improve issue title formatting

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -210,8 +210,35 @@ jobs:
           EOF
           )
 
-          # Use CRITICAL/HIGH count for title (more actionable)
-          TITLE="[Trivy] $IMAGE: $ACTIONABLE_COUNT critical/high vulnerabilities found"
+          # Build title dynamically based on severity counts
+          TITLE_PARTS=()
+          if [ "$CRITICAL" -gt 0 ]; then
+            if [ "$CRITICAL" -eq 1 ]; then
+              TITLE_PARTS+=("$CRITICAL critical vulnerability")
+            else
+              TITLE_PARTS+=("$CRITICAL critical vulnerabilities")
+            fi
+          fi
+          if [ "$HIGH" -gt 0 ]; then
+            if [ "$HIGH" -eq 1 ]; then
+              TITLE_PARTS+=("$HIGH high vulnerability")
+            else
+              TITLE_PARTS+=("$HIGH high vulnerabilities")
+            fi
+          fi
+
+          # Join title parts with comma, or fallback to MEDIUM if no CRITICAL/HIGH
+          if [ "${#TITLE_PARTS[@]}" -gt 0 ]; then
+            TITLE_TEXT=$(IFS=", "; echo "${TITLE_PARTS[*]}")
+            TITLE="[Trivy] $IMAGE: $TITLE_TEXT found"
+          else
+            # Only MEDIUM vulnerabilities present
+            if [ "$MEDIUM" -eq 1 ]; then
+              TITLE="[Trivy] $IMAGE: $MEDIUM medium vulnerability found"
+            else
+              TITLE="[Trivy] $IMAGE: $MEDIUM medium vulnerabilities found"
+            fi
+          fi
 
           # Build labels based on severity
           LABELS="security,trivy"


### PR DESCRIPTION
## Summary

Improves the Trivy scan issue title formatting to separate CRITICAL and HIGH vulnerability counts instead of bundling them, and only shows severity levels that have vulnerabilities.

**Changes:**
- Separate CRITICAL and HIGH counts in issue title
- Only show severity levels with vulnerabilities > 0
- Handle singular vs plural forms correctly
- Fallback to MEDIUM if no CRITICAL/HIGH vulnerabilities

**Examples:**
- `[Trivy] gastown-dev: 4 high vulnerabilities found` (0 CRITICAL, 4 HIGH)
- `[Trivy] firemerge: 2 critical vulnerabilities, 3 high vulnerabilities found` (2 CRITICAL, 3 HIGH)  
- `[Trivy] chrony: 1 critical vulnerability found` (1 CRITICAL, 0 HIGH)
- `[Trivy] sungather: 5 medium vulnerabilities found` (0 CRITICAL, 0 HIGH - edge case)

**Before:** `[Trivy] gastown-dev: 4 critical/high vulnerabilities found`  
**After:** `[Trivy] gastown-dev: 4 high vulnerabilities found`

Builds on #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)