### PR TITLE
fix(workflows): remove approval step from dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,14 +17,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve PR
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: |
-          gh pr review --repo "${{ github.repository }}" --approve "$PR_NUMBER"
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |


### PR DESCRIPTION
## Summary
Removes the approval step that was failing due to GITHUB_TOKEN permissions.

## Details
- GitHub Actions GITHUB_TOKEN cannot approve pull requests
- The main branch doesn't have protection rules requiring approval
- The workflow now just enables auto-merge directly
- Auto-merge will merge the PR once all required status checks pass

## Related
- Fixes the issue discovered in workflow run 20912281665
- Will test on PR #112 after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)