### PR TITLE
fix(trivy): remove stale severity labels on issue updates

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -267,7 +267,7 @@ jobs:
 
           if [ -n "$EXISTING" ]; then
             # Update existing issue (title, body, and labels)
-            gh issue edit "$EXISTING" --title "$TITLE" --body "$BODY" --add-label "$LABELS"
+            gh issue edit "$EXISTING" --title "$TITLE" --body "$BODY" --remove-label "critical,high,medium" --add-label "$LABELS"
             echo "Updated issue #$EXISTING"
           else
             # Create new issue with labels


### PR DESCRIPTION
## Summary
- Fixed label management bug where old severity labels persisted after vulnerability resolution
- Modified line 270 to remove all severity labels before adding current ones
- Single atomic operation using both --remove-label and --add-label flags

## Problem
Issue #21 (firemerge) shows "2 medium vulnerabilities" but has stale "high" label because --add-label only adds, never removes.

## Solution
Add --remove-label "critical,high,medium" before --add-label in the gh issue edit command.

When both flags are used together, GitHub CLI silently ignores non-existent labels, making this safe for all cases (first-time scans, partial severity labels, etc).

## Test Plan
- [ ] MegaLinter passes
- [ ] Manual workflow dispatch trigger
- [ ] Verify issue #21 loses stale "high" label after next scan
- [ ] Confirm non-severity labels are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)