### PR TITLE
fix(trivy): split label removal and addition into separate commands

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -267,7 +267,13 @@ jobs:
 
           if [ -n "$EXISTING" ]; then
             # Update existing issue (title, body, and labels)
-            gh issue edit "$EXISTING" --title "$TITLE" --body "$BODY" --remove-label "critical,high,medium" --add-label "$LABELS"
+            # First, remove any existing severity labels (must be separate command to avoid conflicts)
+            EXISTING_SEVERITY=$(gh issue view "$EXISTING" --json labels -q '.labels[].name' | grep -E '^(critical|high|medium)$' | paste -sd, || echo "")
+            if [ -n "$EXISTING_SEVERITY" ]; then
+              gh issue edit "$EXISTING" --remove-label "$EXISTING_SEVERITY"
+            fi
+            # Then update title, body, and add current labels
+            gh issue edit "$EXISTING" --title "$TITLE" --body "$BODY" --add-label "$LABELS"
             echo "Updated issue #$EXISTING"
           else
             # Create new issue with labels


### PR DESCRIPTION
## Summary
- Fixes issue where removing and adding the same label in one command causes GitHub CLI to treat it as a no-op
- Split the label management into two separate operations

## Problem
PR #121 attempted to fix stale labels by using:
```bash
gh issue edit --remove-label "critical,high,medium" --add-label "security,trivy,medium"
```

However, when the same label appears in both remove and add (e.g., "medium"), GitHub CLI treats this as a conflict/no-op and the label is not added back.

Issue #21 (firemerge) now has only "security" and "trivy" labels but is missing the "medium" label despite having 2 medium vulnerabilities.

## Solution
Split into two separate commands:
1. **First**: Query existing severity labels and remove only those that exist
2. **Second**: Update title, body, and add current labels

This ensures labels can be properly removed and re-added without conflicts.

## Test Plan
- [ ] MegaLinter passes
- [ ] Manual workflow dispatch trigger
- [ ] Verify issue #21 gets "medium" label back
- [ ] Verify stale labels are still properly removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)