### PR TITLE
fix(trivy): improve issue formatting for MEDIUM-only vulnerabilities and add workflow links

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -184,12 +184,11 @@ jobs:
             exit 0
           fi
 
-          # Build vulnerability table from CRITICAL/HIGH only (if needed)
-          if [ "$ACTIONABLE_COUNT" -gt 0 ]; then
-            VULN_TABLE=$(echo "$CRITICAL_HIGH_VULNS" | jq -r '
-              .[] | "| \(.id) | \(.severity) | \(.package) | \(.installed) | \(.fixed) |"
-            ')
-          fi
+          # Build vulnerability table from CRITICAL/HIGH only
+          # shellcheck disable=SC2034  # Used in heredoc below
+          VULN_TABLE=$(echo "$CRITICAL_HIGH_VULNS" | jq -r '
+            .[] | "| \(.id) | \(.severity) | \(.package) | \(.installed) | \(.fixed) |"
+          ')
 
           # Create issue body with CRITICAL/HIGH table and MEDIUM summary
           BODY=$(cat <<EOF


### PR DESCRIPTION
## Summary

Fixes Trivy scan issue formatting when only MEDIUM severity vulnerabilities are present:

1. **Hide empty CRITICAL/HIGH table** - Only show the vulnerability table when CRITICAL or HIGH vulnerabilities exist
2. **Add workflow run links** - Provide clickable links to view full Trivy scan results
3. **MEDIUM-only summary** - Show helpful "Summary" section instead of empty table for MEDIUM-only cases

## Changes

- Modified `.github/workflows/trivy-scan.yaml` issue body creation logic
- Conditionally render CRITICAL/HIGH table based on `ACTIONABLE_COUNT`
- Added `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID` links

## Test Plan

After merge:
1. Manually dispatch Trivy scan workflow
2. Verify issue #21 (firemerge) shows "Summary" section with workflow link, no empty table
3. Verify issue #115 (gastown-dev) shows table + workflow link in note

## Related Issues

- Fixes rendering in #21 (firemerge - MEDIUM only)
- Improves #115 (gastown-dev - HIGH + MEDIUM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)