### PR TITLE
fix(trivy): remove escaping on GitHub environment variables in URLs

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -209,14 +209,14 @@ jobs:
           TABLE
             if [ "$MEDIUM" -gt 0 ]; then
               echo ""
-              echo "**Note:** $MEDIUM MEDIUM severity vulnerabilities not shown in table. [View full Trivy scan results](\$GITHUB_SERVER_URL/\$GITHUB_REPOSITORY/actions/runs/\$GITHUB_RUN_ID)."
+              echo "**Note:** $MEDIUM MEDIUM severity vulnerabilities not shown in table. [View full Trivy scan results]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
             fi
           fi)$(if [ "$ACTIONABLE_COUNT" -eq 0 ] && [ "$MEDIUM" -gt 0 ]; then
             cat <<MEDIUMONLY
 
           ### Summary
 
-          Only MEDIUM severity vulnerabilities detected. [View full Trivy scan results](\$GITHUB_SERVER_URL/\$GITHUB_REPOSITORY/actions/runs/\$GITHUB_RUN_ID) for details.
+          Only MEDIUM severity vulnerabilities detected. [View full Trivy scan results]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) for details.
           MEDIUMONLY
           fi)
 


### PR DESCRIPTION
## Summary

Fixes environment variable expansion in Trivy scan issue body URLs.

## Problem

After the previous PR #125, the GitHub environment variables were escaped with backslashes, causing them to appear as literal strings instead of being expanded to actual URLs:
- `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID` (literal)
- Instead of: `https://github.com/anthony-spruyt/container-images/actions/runs/20915918285` (expanded)

## Changes

- Removed backslash escapes from `$GITHUB_SERVER_URL`, `$GITHUB_REPOSITORY`, and `$GITHUB_RUN_ID`
- Variables now expand correctly within the heredoc

## Test Plan

After merge:
1. Manually dispatch Trivy scan workflow
2. Verify issue #21 shows clickable workflow link
3. Verify issue #115 shows clickable workflow link

## Related Issues

- Follow-up to #125
- Fixes #21 (firemerge)
- Improves #115 (gastown-dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)