### PR TITLE
feat(renovate): enable automerge for minor and patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,10 @@
   suppressNotifications: ["prIgnoreNotification"],
   commitBodyTable: true,
   rebaseWhen: "conflicted",
+  // Automerge minor and patch updates when CI passes
+  automerge: true,
+  automergeType: "pr",
+  automergeStrategy: "squash",
   enabledManagers: [
     "custom.regex",
     "dockerfile",
@@ -89,6 +93,16 @@
     {
       matchManagers: ["npm"],
       labels: ["renovate/npm"],
+    },
+    // Automerge minor and patch updates
+    {
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+    // Do not automerge major updates
+    {
+      matchUpdateTypes: ["major"],
+      automerge: false,
     },
   ],
 }


### PR DESCRIPTION
## Summary
- Enables Renovate automerge for minor and patch dependency updates
- Reduces manual merge overhead for low-risk updates

## Test plan
- [ ] Verify Renovate config is valid
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)