### PR TITLE
fix(ci): trigger builds on assets folder changes

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,6 +23,7 @@ on:
     paths:
       - "**/Dockerfile"
       - "**/metadata.yaml"
+      - "**/assets/**"
 
 # Permissions required by reusable workflow (image-pipeline.yaml)
 permissions:
@@ -67,8 +68,8 @@ jobs:
             fi
             echo "images=[\"$INPUT_IMAGE\"]" >> "$GITHUB_OUTPUT"
           else
-            # Find directories with changed Dockerfiles or metadata
-            CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E '^[a-zA-Z0-9_-]+/(Dockerfile|metadata\.yaml)$' | cut -d'/' -f1 | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            # Find directories with changed Dockerfiles, metadata, or assets
+            CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E '^[a-zA-Z0-9_-]+/(Dockerfile|metadata\.yaml|assets/)' | cut -d'/' -f1 | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
             if [ "$CHANGED" = "[]" ] || [ -z "$CHANGED" ]; then
               echo "images=[]" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
## Summary

- Add `**/assets/**` to workflow path triggers
- Update detect-changes to find directories with assets changes

The build-and-push workflow was only triggering on Dockerfile and metadata.yaml changes, missing changes to install scripts and other assets that affect the built image.

## Test plan

- [ ] Workflow triggers correctly on assets changes

🤖 Generated with [Claude Code](https://claude.ai/code)