### PR TITLE
fix(gastown-dev): use direct download for flux CLI installation

### DIFF
--- a/gastown-dev/assets/scripts/install-flux.sh
+++ b/gastown-dev/assets/scripts/install-flux.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 set -euo pipefail
 
-curl -s https://fluxcd.io/install.sh | bash
+# renovate: depName=fluxcd/flux2 datasource=github-releases
+VERSION="v2.7.5"
 
-# ✅ Verify installation
-if command -v flux &> /dev/null; then
-  echo "✅ Flux is ready: $(flux --version)"
-else
-  echo "❌ Flux installation failed. Please check the install script or install manually:"
-  echo "👉 https://fluxcd.io/flux/installation/"
-  exit 1
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Remove existing to ensure version update
+if [[ -f /usr/local/bin/flux ]]; then
+  rm -f /usr/local/bin/flux
 fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+TARBALL="flux_${VERSION#v}_linux_${ARCH}.tar.gz"
+curl -Lo "$TMPDIR/$TARBALL" "https://github.com/fluxcd/flux2/releases/download/${VERSION}/${TARBALL}"
+curl -Lo "$TMPDIR/${TARBALL}.sha256" "https://github.com/fluxcd/flux2/releases/download/${VERSION}/flux_${VERSION#v}_checksums.txt"
+(cd "$TMPDIR" && grep "$TARBALL" "${TARBALL}.sha256" | sha256sum --check)
+tar -xzf "$TMPDIR/$TARBALL" -C "$TMPDIR"
+mv "$TMPDIR/flux" /usr/local/bin/flux
+chmod +x /usr/local/bin/flux
+
+echo "✅ Flux CLI ${VERSION} installed successfully."


### PR DESCRIPTION
## Summary
- Fix flux CLI installation failing silently due to GitHub API rate limiting
- Pin flux to v2.7.5 with Renovate auto-update comment for version management
- Download directly from GitHub releases with checksum verification

## Context
The previous installation method using `curl -s https://fluxcd.io/install.sh | bash` was failing silently because the install script fetches release metadata from `api.github.com` which has a 60 requests/hour limit for unauthenticated requests. This caused the gastown-dev image tests to fail when `flux --version` was called.

## Test plan
- [x] Built image locally with `docker build -t gastown-dev:test gastown-dev/`
- [x] Ran test script with `./gastown-dev/test.sh gastown-dev:test`
- [x] Verified flux CLI v2.7.5 is installed and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)