### PR TITLE
fix(rulesets): remove invalid renovate integration bypass

### DIFF
--- a/.github/rulesets/pr-rules.json
+++ b/.github/rulesets/pr-rules.json
@@ -7,11 +7,6 @@
       "actor_id": 5,
       "actor_type": "RepositoryRole",
       "bypass_mode": "always"
-    },
-    {
-      "actor_id": 29139,
-      "actor_type": "Integration",
-      "bypass_mode": "always"
     }
   ],
   "conditions": {


### PR DESCRIPTION
## Summary

- Remove Renovate app bypass from pr-rules.json (app ID 29139 not available for repository rulesets)
- Renovate auto-merge still works because:
  - Admin can bypass approval requirement
  - Renovate PRs pass CI (lint skipped, build runs)
  - GitHub auto-merge enabled in repo settings

🤖 Generated with [Claude Code](https://claude.ai/code)