### PR TITLE
chore(sungather): update upstream to forked repository

### DIFF
--- a/sungather/README.md
+++ b/sungather/README.md
@@ -2,7 +2,7 @@
 
 Python tool that collects data from Sungrow Inverters using ModbusTcpClient and exports to various platforms.
 
-- **Upstream:** <https://github.com/bohdan-s/SunGather>
+- **Upstream:** <https://github.com/anthony-spruyt/SunGather>
 - **Container:** `ghcr.io/anthony-spruyt/sungather`
 
 ## Features
@@ -42,7 +42,7 @@ metadata:
   name: sungather-config
 data:
   config.yaml: |
-    # See https://github.com/bohdan-s/SunGather/blob/master/config-example.yaml
+    # See https://github.com/anthony-spruyt/SunGather/blob/master/config-example.yaml
     inverter:
       host: "192.168.1.100"
       port: 502
@@ -101,7 +101,7 @@ spec:
 
 ## Configuration
 
-SunGather requires a `config.yaml` file. See the [upstream config-example.yaml](https://github.com/bohdan-s/SunGather/blob/master/SunGather/config-example.yaml) for all available options.
+SunGather requires a `config.yaml` file. See the [upstream config-example.yaml](https://github.com/anthony-spruyt/SunGather/blob/master/SunGather/config-example.yaml) for all available options.
 
 **Minimum configuration:**
 
@@ -156,7 +156,7 @@ The `n8n-release-watcher.json` workflow automatically detects new SunGather rele
 
 ### What it does
 
-1. Checks GitHub daily (midnight UTC) for new tags on `bohdan-s/SunGather`
+1. Checks GitHub daily (midnight UTC) for new tags on `anthony-spruyt/SunGather`
 2. Compares with the last processed version (stored in workflow static data)
 3. If a new version is found:
    - Triggers the container build workflow with the exact upstream tag
@@ -221,6 +221,5 @@ On subsequent runs, `isNew` will be `false` until a new release is published ups
 
 ## Related
 
-- [Upstream Repository](https://github.com/bohdan-s/SunGather)
-- [Upstream Documentation](https://github.com/bohdan-s/SunGather#readme)
-- [Upstream Docker Hub](https://hub.docker.com/r/bohdans/sungather)
+- [Upstream Repository](https://github.com/anthony-spruyt/SunGather)
+- [Upstream Documentation](https://github.com/anthony-spruyt/SunGather#readme)

--- a/sungather/metadata.yaml
+++ b/sungather/metadata.yaml
@@ -1,6 +1,6 @@
 ---
 # SunGather - Data collector for Sungrow Inverters
-# https://github.com/bohdan-s/SunGather
+# https://github.com/anthony-spruyt/SunGather
 
-upstream: bohdan-s/SunGather
+upstream: anthony-spruyt/SunGather
 version: v0.5.3

--- a/sungather/n8n-release-watcher.json
+++ b/sungather/n8n-release-watcher.json
@@ -19,7 +19,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.github.com/repos/bohdan-s/SunGather/tags",
+        "url": "https://api.github.com/repos/anthony-spruyt/SunGather/tags",
         "options": {}
       },
       "id": "8f3771e2-6bef-402c-b261-8d718b11a216",


### PR DESCRIPTION
## Summary
- Update SunGather image to use `anthony-spruyt/SunGather` fork instead of `bohdan-s/SunGather`
- Update n8n release watcher to monitor the fork for new releases
- Remove outdated Docker Hub reference from README

## Test plan
- [ ] Verify CI passes
- [ ] Confirm metadata.yaml points to correct upstream
- [ ] Verify n8n workflow fetches tags from the fork

🤖 Generated with [Claude Code](https://claude.ai/code)