### PR TITLE
chore: cleanup docs and vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,6 @@
   "editor.formatOnSave": true,
   "editor.codeActions.triggerOnFocusChange": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "prettier.configPath": ".prettierrc.yaml",
-  "prettier.ignorePath": ".prettierignore",
   "explorer.sortOrder": "type",
   "editor.tabSize": 2,
   "chat.agent.enabled": false

--- a/chrony/README.md
+++ b/chrony/README.md
@@ -97,7 +97,7 @@ The `n8n-release-watcher.json` workflow automatically detects new chrony package
 
 ### What it does
 
-1. Checks daily (midnight UTC) for chrony package updates in Alpine Linux
+1. Checks daily (11PM AEST) for chrony package updates in Alpine Linux
 2. Dynamically reads the Alpine version from this repo's Dockerfile
 3. Fetches the corresponding APKBUILD from Alpine's Git repository
 4. Compares the package version with the last processed version (stored in workflow static data)

--- a/firemerge/README.md
+++ b/firemerge/README.md
@@ -2,7 +2,7 @@
 
 Semi-automated transaction entry for Firefly III.
 
-- **Upstream:** <https://github.com/lvu/firemerge>
+- **Upstream:** <https://github.com/anthony-spruyt/firemerge>
 - **Container:** `ghcr.io/anthony-spruyt/firemerge`
 
 ## n8n Release Watcher
@@ -11,7 +11,7 @@ The `n8n-release-watcher.json` workflow automatically detects new Firemerge rele
 
 ### What it does
 
-1. Checks GitHub daily (midnight UTC) for new tags on `lvu/firemerge`
+1. Checks GitHub daily (11PM AEST) for new tags on `anthony-spruyt/firemerge`
 2. Compares with the last processed version (stored in workflow static data)
 3. If a new version is found:
    - Triggers the container build workflow with the exact upstream tag

--- a/firemerge/n8n-release-watcher.json
+++ b/firemerge/n8n-release-watcher.json
@@ -19,7 +19,7 @@
     },
     {
       "parameters": {
-        "url": "https://api.github.com/repos/lvu/firemerge/tags",
+        "url": "https://api.github.com/repos/anthony-spruyt/firemerge/tags",
         "options": {}
       },
       "id": "0c017bb2-8877-4ed7-b8a7-824db324cf34",

--- a/sungather/README.md
+++ b/sungather/README.md
@@ -156,7 +156,7 @@ The `n8n-release-watcher.json` workflow automatically detects new SunGather rele
 
 ### What it does
 
-1. Checks GitHub daily (midnight UTC) for new tags on `bohdan-s/SunGather`
+1. Checks GitHub daily (11PM AEST) for new tags on `bohdan-s/SunGather`
 2. Compares with the last processed version (stored in workflow static data)
 3. If a new version is found:
    - Triggers the container build workflow with the exact upstream tag


### PR DESCRIPTION
## Summary
- Remove unused prettier config paths from vscode settings
- Update n8n schedule times from "midnight UTC" to "11PM AEST" in READMEs
- Fix firemerge upstream repo reference (lvu → anthony-spruyt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)