### PR TITLE
chore: add megalinter image to readme and simplify ci bot skip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,11 +122,11 @@ jobs:
     name: Lint
     needs: detect-changes
     runs-on: ubuntu-latest
-    # Run if images or scripts changed (skip for renovate PRs)
+    # Run if images or scripts changed (skip for renovate/dependabot bot commits)
     if: |
       (needs.detect-changes.outputs.images != '[]' || needs.detect-changes.outputs.scripts == 'true') &&
       github.actor != 'renovate[bot]' &&
-      !startsWith(github.head_ref || '', 'renovate/')
+      github.actor != 'dependabot[bot]'
     concurrency:
       group: ${{ github.workflow }}-lint-${{ github.ref }}
       cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for development environment setup.
 
 ## Available Images
 
-| Image       | Upstream                                                                | Registry                             |
-| ----------- | ----------------------------------------------------------------------- | ------------------------------------ |
-| chrony      | Local (no upstream)                                                     | `ghcr.io/anthony-spruyt/chrony`      |
-| firemerge   | [anthony-spruyt/firemerge](https://github.com/anthony-spruyt/firemerge) | `ghcr.io/anthony-spruyt/firemerge`   |
-| gastown-dev | Local (no upstream)                                                     | `ghcr.io/anthony-spruyt/gastown-dev` |
+| Image                       | Upstream                                                                | Registry                                             |
+| --------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| chrony                      | Local (no upstream)                                                     | `ghcr.io/anthony-spruyt/chrony`                      |
+| firemerge                   | [anthony-spruyt/firemerge](https://github.com/anthony-spruyt/firemerge) | `ghcr.io/anthony-spruyt/firemerge`                   |
+| gastown-dev                 | Local (no upstream)                                                     | `ghcr.io/anthony-spruyt/gastown-dev`                 |
+| megalinter-container-images | [oxsecurity/megalinter](https://github.com/oxsecurity/megalinter)       | `ghcr.io/anthony-spruyt/megalinter-container-images` |
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Add `megalinter-container-images` to Available Images table in README
- Simplify lint skip condition to only check `github.actor` (removed branch name checks)
- Human commits to bot branches now get linted properly
- Add `dependabot[bot]` to skip list alongside `renovate[bot]`

## Test plan
- [x] Local lint passes
- [ ] CI workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)