### PR TITLE
fix(megalinter-factory): support all MegaLinter installation types

### DIFF
--- a/.claude/commands/create-megalinter-flavor.md
+++ b/.claude/commands/create-megalinter-flavor.md
@@ -47,7 +47,43 @@ This extracts linter information directly from MegaLinter's descriptors.
 
 ## Step 3: Get Linter Selection
 
-If linters were provided as arguments, validate each one exists in MegaLinter.
+If linters were provided as arguments, validate each one exists in MegaLinter (check extractor output).
+
+**Important**: Some linters are already included in the `ci_light` base flavor. The extractor output shows `ci_light has N linters` - these DON'T need to be in `custom_linters`. Only add linters that aren't in the base flavor.
+
+Linters already in `ci_light` (24 total):
+
+- BASH_SHELLCHECK, BASH_SHFMT
+- DOCKERFILE_HADOLINT
+- JSON_JSONLINT, JSON_PRETTIER, JSON_V8R, JSON_ESLINT_PLUGIN_JSONC
+- YAML_YAMLLINT, YAML_PRETTIER, YAML_V8R
+- REPOSITORY_GITLEAKS, REPOSITORY_SECRETLINT, REPOSITORY_TRIVY, REPOSITORY_TRIVY_SBOM
+- REPOSITORY_GRYPE, REPOSITORY_SYFT, REPOSITORY_TRUFFLEHOG, REPOSITORY_LS_LINT, REPOSITORY_GIT_DIFF
+- COPYPASTE_JSCPD, MAKEFILE_CHECKMAKE, XML_XMLLINT, ENV_DOTENV_LINTER, GROOVY_NPM_GROOVY_LINT
+
+**NOT in `ci_light`** (must be added as custom_linters):
+
+- ACTION_ACTIONLINT
+- MARKDOWN_MARKDOWNLINT, SPELL_LYCHEE
+- PYTHON_PYLINT, PYTHON_RUFF
+- (and most language-specific linters)
+
+**Built-in linters requiring specific base flavors:**
+
+Some linters are built-in (no install needed) but require tools only available in specific base flavors:
+
+| Linter                  | Required Base Flavor              |
+| ----------------------- | --------------------------------- |
+| TERRAFORM_TERRAFORM_FMT | `terraform`                       |
+| CSHARP_DOTNET_FORMAT    | `dotnet` or `dotnetweb`           |
+| VBDOTNET_DOTNET_FORMAT  | `dotnet` or `dotnetweb`           |
+| SWIFT_SWIFTLINT         | `swift`                           |
+| GO\_\* linters          | `go`                              |
+| JAVA\_\* linters        | `java`                            |
+| PYTHON\_\* linters      | `python` (or `ci_light` for some) |
+| RUST_CLIPPY             | `rust`                            |
+
+If a user requests these linters with `ci_light` base, warn them they need to change `upstream_image` to the appropriate flavor (e.g., `oxsecurity/megalinter-terraform`).
 
 If NO linters were provided, use AskUserQuestion to help the user select linters interactively. Present linters grouped by category:
 

--- a/megalinter-factory/templates/Dockerfile.j2
+++ b/megalinter-factory/templates/Dockerfile.j2
@@ -23,6 +23,11 @@ FROM {{ flavor.upstream_image }}
 {% else -%}
 FROM oxsecurity/megalinter-{{ flavor.base_flavor }}:{{ flavor.upstream_tag }}{{ '@' + flavor.upstream_digest if flavor.upstream_digest else '' }}
 {% endif -%}
+{% if apk_packages %}
+
+# Install Alpine package dependencies for custom linters
+RUN apk add --no-cache {{ apk_packages | join(' ') }}
+{%- endif %}
 {% if docker_binary_linters %}
 
 # Add binary linters from source images
@@ -60,8 +65,25 @@ RUN go install {{ linter.package }}@v${{ '{' }}{{ linter.name | upper }}_VERSION
 
 # Add cargo-based linters
 {% for linter in cargo_linters -%}
+RUN cargo install {{ linter.package }}
+{% endfor %}
+{%- endif %}
+{%- if gem_linters %}
+
+# Add gem-based linters (ruby already available in MegaLinter)
+{% for linter in gem_linters -%}
 ARG {{ linter.name | upper }}_VERSION={{ linter.version }}
-RUN cargo install {{ linter.package }} --version ${{ '{' }}{{ linter.name | upper }}_VERSION{{ '}' }}
+{% endfor -%}
+RUN gem install --no-document{% for linter in gem_linters %} {{ linter.package }}:${{ '{' }}{{ linter.name | upper }}_VERSION{{ '}' }}{% endfor %}
+{%- endif %}
+{%- if script_linters %}
+
+# Add script-installed linters (using upstream MegaLinter dockerfile instructions)
+{% for linter in script_linters -%}
+# {{ linter.linter_key }}
+{% for line in linter.dockerfile -%}
+{{ line }}
+{% endfor %}
 {% endfor %}
 {%- endif %}
 {%- if flavor.extra_dockerfile %}


### PR DESCRIPTION
## Summary

- Extend the extractor to capture **128 of 133** MegaLinter linters (up from 75)
- Add support for new installation types: `script`, `cargo`, `gem`, `apk`, `dockerfile`
- Fix several bugs in version resolution and stage name parsing
- Update command documentation with accurate ci_light linter list and base flavor requirements

## Changes

### New installation types supported

| Type | Description | Examples |
|------|-------------|----------|
| `script` | wget/curl install scripts | REPOSITORY_TRIVY, GO_GOLANGCI_LINT |
| `cargo` | Rust packages | RUST_CLIPPY |
| `gem` | Ruby packages | RUBY_RUBOCOP, PUPPET_PUPPET_LINT |
| `apk` | Alpine-only installs | C_CLANG_FORMAT, XML_XMLLINT |
| `dockerfile` | Generic RUN commands | BASH_BASH_EXEC |

### Bug fixes

- Fix version prefix resolution for tags like `v${VAR}` (TERRAFORM_TFLINT)
- Fix stage name regex to allow hyphens (EDITORCONFIG_EDITORCONFIG_CHECKER)
- Fix `descriptor_flavors` inheritance from descriptor to linter level
- Correct ci_light linter count (24, not 133)

### Generator improvements

- Add APK dependency installation to Dockerfile
- Add gem package installation support
- Collect APK deps only for custom linters in each flavor

### Command updates

- Document linters already in ci_light base (24 total)
- Add table of built-in linters requiring specific base flavors
- Warn users when linters need non-ci_light bases

## Test plan

- [x] Verified extractor captures 128 linters
- [x] Verified generator produces valid Dockerfile for megalinter-container-images
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)