### PR TITLE
fix(ci): prevent race condition in concurrent image builds

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -45,6 +45,13 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
 
+# Prevent race condition: only one build per image at a time
+# With cancel-in-progress: false, the next queued build waits for the current one
+# When it starts, check-release will see any releases created by the previous build
+concurrency:
+  group: release-${{ inputs.image }}
+  cancel-in-progress: false
+
 jobs:
   check-release:
     name: Check Release


### PR DESCRIPTION
## Summary

- Add concurrency control to `_image-pipeline.yaml` to prevent two builds of the same image from running simultaneously
- Uses `concurrency.group: release-${{ inputs.image }}` to serialize builds per image
- With `cancel-in-progress: false`, queued builds wait rather than get cancelled

## Problem

When two commits to main trigger CI for the same image simultaneously:
1. Both builds query `gh release list` and see the same existing releases
2. Both calculate the same `auto_patch` version (e.g., `1.2.6`)
3. Both try to create the same release tag → conflict

## Solution

Builds for the same image now run sequentially. The second build waits for the first to complete, then sees the newly created release and calculates the correct next version.

| Scenario | Behavior |
|----------|----------|
| Different images | Run in parallel (fast) |
| Same image | Run sequentially (safe) |

## Test plan

- [ ] Verify workflow syntax is valid (actionlint passed in MegaLinter)
- [ ] Test with two rapid commits to an `auto_patch: true` image
- [ ] Confirm second build waits and calculates correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)