### PR TITLE
feat(ci): implement container retention policy for GHCR images

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -1,0 +1,24 @@
+name: Container Retention Policy
+
+on:
+  schedule:
+    - cron: "0 5 * * 0" # Weekly, Sundays at 5 AM UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no deletions)"
+        type: boolean
+        default: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: anthony-spruyt
+          token: ${{ secrets.CONTAINER_RETENTION_TOKEN }}
+          image-names: "gastown-dev megalinter-*"
+          cut-off: 4w
+          keep-n-most-recent: 5
+          dry-run: ${{ inputs.dry_run || 'false' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,15 @@ For upstream sources that Renovate cannot monitor (e.g., Alpine packages), use n
 - **Push to main**: Auto-builds on Dockerfile/metadata.yaml/flavor.yaml changes
 - **workflow_dispatch**: Manual trigger with `image` and `version` inputs
 
+## Container Retention
+
+Old container images are automatically cleaned up weekly:
+
+- Images older than 4 weeks are deleted
+- 5 most recent versions always kept
+- Targets: `gastown-dev`, `megalinter-*`
+- Workflow: `.github/workflows/container-retention.yaml`
+
 ## Commits
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## Summary

- Add scheduled workflow using `snok/container-retention-policy@v3` to automatically delete old container image versions
- Target high-churn images: `gastown-dev` and `megalinter-*`
- Policy: Delete versions older than 4 weeks, always keep 5 most recent
- Schedule: Weekly on Sundays at 5 AM UTC
- Supports manual trigger with `dry_run` option for testing

## Motivation

`gastown-dev` with `auto_patch: true` created **42 releases in 12 days**. All container images are kept indefinitely in GHCR with no cleanup mechanism.

## Prerequisites

Before using, create a PAT with `packages:write` scope and add as repository secret `CONTAINER_RETENTION_TOKEN`.

## Test plan

- [ ] Add `CONTAINER_RETENTION_TOKEN` secret with PAT that has `packages:write` scope
- [ ] Run workflow manually with `dry_run: true` via Actions tab
- [ ] Verify logs show expected old gastown-dev versions as deletion candidates
- [ ] Run with `dry_run: false` to perform actual cleanup
- [ ] Verify old versions are removed from GHCR packages page

Closes #270

🤖 Generated with [Claude Code](https://claude.ai/claude-code)