### PR TITLE
fix(ci): use PAT for container retention to support wildcards

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -13,13 +13,12 @@ on:
 jobs:
   cleanup-containers:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
+    permissions: {}
     steps:
       - uses: snok/container-retention-policy@v3.0.1
         with:
           account: anthony-spruyt
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CONTAINER_RETENTION_TOKEN }}
           image-names: "gastown-dev megalinter-*"
           cut-off: 4w
           keep-n-most-recent: 5


### PR DESCRIPTION
## Summary

- Switch from `GITHUB_TOKEN` to `CONTAINER_RETENTION_TOKEN` (classic PAT)
- `GITHUB_TOKEN` cannot list packages, preventing wildcard patterns like `megalinter-*`

## Prerequisites

Classic PAT with `write:packages` scope added as `CONTAINER_RETENTION_TOKEN` secret.

## Test plan

- [ ] Run workflow with `dry_run: true`
- [ ] Verify it lists expected images for deletion

🤖 Generated with [Claude Code](https://claude.ai/claude-code)