### PR TITLE
fix(ci): use 'user' account type for container retention

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: snok/container-retention-policy@v3.0.1
         with:
-          account: anthony-spruyt
+          account: user
           token: ${{ secrets.CONTAINER_RETENTION_TOKEN }}
           image-names: "gastown-dev megalinter-*"
           cut-off: 4w


### PR DESCRIPTION
## Summary

Change `account: anthony-spruyt` to `account: user`.

For personal accounts, snok/container-retention-policy requires the literal string `user`, not the username.

## Test plan

- [ ] Run workflow with `dry_run: true`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)