### PR TITLE
feat(megalinter-xfg): add MegaLinter flavor for xfg project

### DIFF
--- a/megalinter-xfg/flavor.yaml
+++ b/megalinter-xfg/flavor.yaml
@@ -1,0 +1,25 @@
+# MegaLinter Flavor Factory Configuration
+# Source of truth for megalinter-xfg flavor
+#
+# To regenerate Dockerfile and test.sh:
+#   python megalinter-factory/generate.py megalinter-xfg/
+#
+# Linter versions are automatically extracted from MegaLinter at build time.
+---
+name: xfg
+description: "MegaLinter flavor for xfg - TypeScript/JavaScript with security scanning"
+
+# Upstream MegaLinter base image (Renovate tracks this)
+# renovate: datasource=docker depName=oxsecurity/megalinter-ci_light
+upstream_image: "oxsecurity/megalinter-ci_light:v9.3.0@sha256:a71e62c83e3b2d52316e7322b9168e1588e9bcf454dbf9b21fc71b0954786e5e"
+
+# Additional linters not in base flavor
+# Just list linter keys - versions come from MegaLinter automatically
+custom_linters:
+  - ACTION_ACTIONLINT
+  - JAVASCRIPT_ESLINT
+  - JAVASCRIPT_PRETTIER
+  - MARKDOWN_MARKDOWNLINT
+  - SPELL_LYCHEE
+  - TYPESCRIPT_ESLINT
+  - TYPESCRIPT_PRETTIER

--- a/megalinter-xfg/metadata.yaml
+++ b/megalinter-xfg/metadata.yaml
@@ -1,0 +1,9 @@
+---
+# Custom MegaLinter flavor: xfg
+# MegaLinter flavor for xfg - TypeScript/JavaScript with security scanning
+#
+# Version is managed independently of upstream - update manually for major changes.
+# auto_patch: true enables automatic patch version increments on rebuild.
+
+version: "v1.0"
+auto_patch: true


### PR DESCRIPTION
## Summary

- Add new MegaLinter flavor `megalinter-xfg` for TypeScript/JavaScript projects
- Based on `ci_light` base (24 linters) + 7 custom linters
- Total: 31 linters

### Custom Linters Added

| Linter | Purpose |
|--------|---------|
| ACTION_ACTIONLINT | GitHub Actions validation |
| JAVASCRIPT_ESLINT | JavaScript linting |
| JAVASCRIPT_PRETTIER | JavaScript formatting |
| MARKDOWN_MARKDOWNLINT | Markdown linting |
| SPELL_LYCHEE | Link checking |
| TYPESCRIPT_ESLINT | TypeScript linting |
| TYPESCRIPT_PRETTIER | TypeScript formatting |

### Base Linters (from ci_light)

Includes BASH_SHELLCHECK, BASH_SHFMT, JSON_JSONLINT, YAML_YAMLLINT, REPOSITORY_GITLEAKS, REPOSITORY_SECRETLINT, REPOSITORY_TRIVY, and 17 others.

## Test plan

- [ ] CI generates Dockerfile and test.sh from flavor.yaml
- [ ] Image builds successfully
- [ ] Linter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)