### PR TITLE
fix(megalinter-factory): use correct linter keys from MegaLinter descriptors

### DIFF
--- a/megalinter-factory/megalinter_extractor.py
+++ b/megalinter-factory/megalinter_extractor.py
@@ -182,12 +182,14 @@ def extract_linter_info(descriptors_dir: Path) -> dict:
         desc = yaml.safe_load(desc_file.read_text())
 
         for linter in desc.get("linters", []):
-            # Build linter key: DESCRIPTOR_LINTERNAME (e.g., ACTION_ACTIONLINT)
+            # Use the 'name' field as the linter key - this is the actual key MegaLinter uses
+            # e.g., JAVASCRIPT_ES, TYPESCRIPT_ES, ACTION_ACTIONLINT
+            # Falls back to constructing from descriptor_id + linter_name if 'name' not present
             descriptor_id = desc.get("descriptor_id", "").upper()
             linter_name_raw = linter.get("linter_name", "")
             # Normalize: replace hyphens with underscores for consistency
             linter_name = linter_name_raw.upper().replace("-", "_")
-            linter_key = f"{descriptor_id}_{linter_name}"
+            linter_key = linter.get("name", f"{descriptor_id}_{linter_name}")
 
             install = linter.get("install", {})
             dockerfile = install.get("dockerfile", [])
@@ -397,8 +399,9 @@ def extract_base_flavor_linters(descriptors_dir: Path) -> dict[str, list[str]]:
         descriptor_flavors = set(desc.get("descriptor_flavors", []))
 
         for linter in desc.get("linters", []):
+            # Use the 'name' field as the linter key (same as extract_linter_info)
             linter_name = linter.get("linter_name", "").upper().replace("-", "_")
-            linter_key = f"{descriptor_id}_{linter_name}"
+            linter_key = linter.get("name", f"{descriptor_id}_{linter_name}")
 
             # Linter-level descriptor_flavors overrides descriptor-level if present
             linter_flavors = linter.get("descriptor_flavors")

--- a/megalinter-xfg/flavor.yaml
+++ b/megalinter-xfg/flavor.yaml
@@ -17,9 +17,9 @@ upstream_image: "oxsecurity/megalinter-ci_light:v9.3.0@sha256:a71e62c83e3b2d5231
 # Just list linter keys - versions come from MegaLinter automatically
 custom_linters:
   - ACTION_ACTIONLINT
-  - JAVASCRIPT_ESLINT
+  - JAVASCRIPT_ES
   - JAVASCRIPT_PRETTIER
   - MARKDOWN_MARKDOWNLINT
   - SPELL_LYCHEE
-  - TYPESCRIPT_ESLINT
+  - TYPESCRIPT_ES
   - TYPESCRIPT_PRETTIER


### PR DESCRIPTION
## Summary

- Fix extractor to use MegaLinter's `name` field as the linter key
- Update megalinter-xfg flavor with correct linter keys

## Problem

The extractor was constructing linter keys incorrectly:
- **Before**: `JAVASCRIPT_ESLINT`, `TYPESCRIPT_ESLINT` (constructed from descriptor_id + linter_name)
- **After**: `JAVASCRIPT_ES`, `TYPESCRIPT_ES` (actual keys from MegaLinter's `name` field)

This caused TS/JS linters to not run because MegaLinter couldn't find them.

## Changes

| File | Change |
|------|--------|
| `megalinter_extractor.py` | Use `linter.get("name")` instead of constructing key |
| `megalinter-xfg/flavor.yaml` | Fix `JAVASCRIPT_ESLINT` → `JAVASCRIPT_ES`, `TYPESCRIPT_ESLINT` → `TYPESCRIPT_ES` |

## Test plan

- [ ] Extractor outputs correct keys (`JAVASCRIPT_ES`, `TYPESCRIPT_ES`)
- [ ] Generator finds linters without warnings
- [ ] megalinter-xfg image builds and runs TS/JS linters

🤖 Generated with [Claude Code](https://claude.com/claude-code)