### PR TITLE
fix(megalinter-factory): add NODE_PATH for ESLint to find global packages

### DIFF
--- a/megalinter-factory/templates/Dockerfile.j2
+++ b/megalinter-factory/templates/Dockerfile.j2
@@ -101,3 +101,8 @@ RUN gem install --no-document{% for linter in gem_linters %} {{ linter.package }
 # Set flavor to 'all' to bypass MegaLinter's flavor validation
 # (custom flavor names like '{{ flavor.name }}' aren't recognized by MegaLinter)
 ENV MEGALINTER_FLAVOR=all
+{% if npm_linters %}
+
+# Make globally installed npm packages discoverable by ESLint
+ENV NODE_PATH=/usr/lib/node_modules
+{%- endif %}


### PR DESCRIPTION
## Summary

Fix ESLint not finding globally installed npm packages like `eslint-config-prettier`.

## Problem

ESLint looks for packages relative to the config file location or cwd, not in global `node_modules`. This causes:
```
ESLint couldn't find the config "prettier" to extend from.
```

## Solution

Add `NODE_PATH=/usr/lib/node_modules` to make globally installed packages discoverable.

## Test plan

- [ ] CI builds all flavors
- [ ] ESLint can find `eslint-config-prettier` and other packages
- [ ] TypeScript/JavaScript linting works in xfg project

🤖 Generated with [Claude Code](https://claude.com/claude-code)