### PR TITLE
fix(chrony): rebuild to fix CVE-2025-15467 (libcrypto3 critical)

### DIFF
--- a/chrony/metadata.yaml
+++ b/chrony/metadata.yaml
@@ -2,4 +2,4 @@
 # Chrony - Minimal NTP server with zero capabilities
 # Custom image for Kubernetes deployments requiring least privilege
 
-version: "4.8-r1"
+version: "4.8-r2"


### PR DESCRIPTION
## Summary

- Bump chrony rebuild version to `4.8-r2` to trigger image rebuild
- Picks up fixed `libcrypto3` 3.5.5-r0 from Alpine repositories

**Vulnerabilities fixed:**
| CVE | Severity | Package | Installed | Fixed |
|-----|----------|---------|-----------|-------|
| CVE-2025-15467 | CRITICAL | libcrypto3 | 3.5.4-r0 | 3.5.5-r0 |
| CVE-2025-69419 | HIGH | libcrypto3 | 3.5.4-r0 | 3.5.5-r0 |
| CVE-2025-69421 | HIGH | libcrypto3 | 3.5.4-r0 | 3.5.5-r0 |

Closes #324

## Test plan

- [ ] PR checks pass (lint)
- [ ] After merge, build workflow triggers automatically
- [ ] New `chrony:4.8-r2` release created
- [ ] Trivy scan shows no critical/high vulnerabilities
- [ ] Issue #324 auto-closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)