### PR TITLE
fix(ci): add actions:write permission for reusable lint workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ on:
         default: true
 
 permissions:
+  actions: write
   attestations: write
   contents: write
   id-token: write


### PR DESCRIPTION
## Summary
- Add missing `actions: write` permission to CI workflow permissions block
- The `repo-operator/_lint.yaml` reusable workflow requires this permission, causing the lint job to fail without it

## Test plan
- [ ] Verify CI workflow passes validation
- [ ] Confirm lint job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)