### PR TITLE
fix(container-retention): use GitHub App token for tag deletion

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -28,12 +28,18 @@ jobs:
 
   cleanup-releases:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    permissions: {}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.GARBO_APP_ID }}
+          private-key: ${{ secrets.GARBO_PRIVATE_KEY }}
+
       - name: Delete old releases and tags
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           CUTOFF_DATE=$(date -d '4 weeks ago' +%s)


### PR DESCRIPTION
## Summary

- Switch `cleanup-releases` job from `GITHUB_TOKEN` to the Container Images Garbo app token (`actions/create-github-app-token`) which has bypass permissions on the `tag-rules` ruleset
- Remove `contents: write` permission (no longer needed — app token provides its own permissions)
- Requires `GARBO_APP_ID` and `GARBO_PRIVATE_KEY` secrets to be configured

Closes #413

## Test plan

- [ ] Verify `GARBO_APP_ID` and `GARBO_PRIVATE_KEY` secrets are added to the repository
- [ ] Run the workflow manually with `dry_run: true` to confirm the app token is generated successfully
- [ ] Run with `dry_run: false` (or wait for next Sunday 5 AM UTC schedule) to confirm tags are deleted without HTTP 422 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)