### PR TITLE
chore(claude-agent): pin Claude CLI version with Renovate tracking

### DIFF
--- a/claude-agent/Dockerfile
+++ b/claude-agent/Dockerfile
@@ -25,8 +25,10 @@ USER node
 RUN safe-chain setup && safe-chain setup-ci
 ENV PATH="/home/node/.safe-chain/shims:${PATH}"
 
-# Claude Code CLI (native installer — shims active via ENV above)
-RUN curl -fsSL https://claude.ai/install.sh | bash
+# Claude Code CLI (native binary — npm datasource tracks versions)
+# renovate: depName=@anthropic-ai/claude-code datasource=npm
+ARG CLAUDE_VERSION="2.1.87"
+RUN curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"
 ENV PATH="/home/node/.local/bin:${PATH}"
 
 # Working directory (node user owns it)


### PR DESCRIPTION
## Summary

- Pin Claude Code CLI to version 2.1.87 via installer argument
- Add Renovate annotation using `@anthropic-ai/claude-code` npm datasource
- Native binary versions match npm package versions

## Linked Issue

Closes #423

## Changes

- `claude-agent/Dockerfile` — add `ARG CLAUDE_VERSION` with Renovate annotation, pass to installer via `bash -s --`

## Testing

- Verified `curl ... | bash -s -- 2.1.87` installs the correct version locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)