### PR TITLE
fix(claude-agent): use numeric UID for PSA restricted compatibility

### DIFF
--- a/claude-agent/Dockerfile
+++ b/claude-agent/Dockerfile
@@ -21,7 +21,7 @@ ARG SAFE_CHAIN_VERSION="1.4.4"
 RUN npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION}"
 
 # Set up safe-chain shims for node user before any npm/pip calls
-USER node
+USER 1000
 RUN safe-chain setup && safe-chain setup-ci
 ENV PATH="/home/node/.safe-chain/shims:${PATH}"
 
@@ -40,5 +40,5 @@ USER root
 COPY assets/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-USER node
+USER 1000
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary

PSA `restricted` requires `runAsNonRoot` with a numeric user. `USER node` causes `CreateContainerConfigError` because K8s can't verify non-root without a numeric UID.

Changes `USER node` → `USER 1000` (3 occurrences in Dockerfile).

## Linked Issue

Ref anthony-spruyt/spruyt-labs#823

## Testing

- Local build + `id` → `uid=1000(node)`
- `claude --version` → `2.1.87`

🤖 Generated with [Claude Code](https://claude.com/claude-code)