### PR TITLE
fix(discord-mcp): add protocol version and stateful mode

### DIFF
--- a/discord-mcp/Dockerfile
+++ b/discord-mcp/Dockerfile
@@ -21,4 +21,6 @@ ENTRYPOINT ["supergateway", \
   "--stdio", "java -jar /app/app.jar", \
   "--outputTransport", "streamableHttp", \
   "--port", "8080", \
-  "--healthEndpoint", "/healthz"]
+  "--healthEndpoint", "/healthz", \
+  "--protocolVersion", "2025-03-26", \
+  "--stateful"]


### PR DESCRIPTION
## Summary
- Add `--protocolVersion 2025-03-26` to supergateway entrypoint (fixes MCP client handshake failure)
- Add `--stateful` flag to keep JVM process alive across requests (avoids cold startup per call)

## Linked Issue
Ref anthony-spruyt/spruyt-labs#841

## Testing
- Rebuild image, deploy to cluster
- Verify agent pods can connect to `http://discord-mcp.discord-mcp.svc:8080/mcp`
- Verify `mcp__discord__read_messages` works from SRE triage agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)