### PR TITLE
refactor(workflows): use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -34,7 +34,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.GARBO_APP_ID }}
+          client-id: ${{ secrets.GARBO_CLIENT_ID }}
           private-key: ${{ secrets.GARBO_PRIVATE_KEY }}
 
       - name: Delete old releases and tags


### PR DESCRIPTION
## Summary
- Replaces deprecated `app-id` input with `client-id` in `container-retention.yaml`
- Pairs with the v3.1.1 action bump in #449

`GARBO_CLIENT_ID` secret is already configured with the app's OAuth client ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)