### PR TITLE
feat(coder-gitops): add image bundling coder CLI + kubectl

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -45,3 +45,7 @@ misconfigurations:
   - id: AVD-DS-0026
     paths:
       - ssh-key-rotation/Dockerfile
+  # Job/CronJob entrypoint — Coder template sync + token rotation, runs to completion
+  - id: AVD-DS-0026
+    paths:
+      - coder-gitops/Dockerfile

--- a/coder-gitops/.trivyignore
+++ b/coder-gitops/.trivyignore
@@ -3,3 +3,10 @@
 CVE-2026-25679
 CVE-2026-32280
 CVE-2026-32282
+
+# Transitive Go deps compiled into upstream coder binary
+# Can't fix without a new coder release
+GHSA-77fj-vx54-gvh7
+CVE-2026-4660
+CVE-2026-24051
+CVE-2026-39883

--- a/coder-gitops/.trivyignore
+++ b/coder-gitops/.trivyignore
@@ -1,0 +1,5 @@
+# Go stdlib CVEs in upstream kubectl binary
+# Compiled into the kubectl release - can't fix without a new k8s release
+CVE-2026-25679
+CVE-2026-32280
+CVE-2026-32282

--- a/coder-gitops/Dockerfile
+++ b/coder-gitops/Dockerfile
@@ -1,0 +1,53 @@
+# coder-gitops: bundles `coder` CLI + `kubectl` for Coder GitOps Jobs
+# (template sync + session-token rotation). Designed for PSA restricted:
+# non-root (UID 1000), read-only rootfs, all caps dropped.
+#
+# Pin to specific digest for supply chain security (renovate updates this)
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+
+# renovate: datasource=github-releases depName=coder/coder
+ARG CODER_VERSION=v2.31.9
+
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.35.3
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache curl jq ca-certificates tzdata bash \
+    && addgroup -g 1000 coder \
+    && adduser -D -u 1000 -G coder -h /home/coder coder
+
+# Install kubectl. Checksum fetched from same release server alongside binary.
+# hadolint ignore=DL4006
+RUN ARCH="$(apk --print-arch)" \
+    && case "${ARCH}" in \
+         x86_64)  KUBE_ARCH=amd64 ;; \
+         aarch64) KUBE_ARCH=arm64 ;; \
+         *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;; \
+       esac \
+    && KUBE_URL="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBE_ARCH}/kubectl" \
+    && curl -fsSL -o /usr/local/bin/kubectl "${KUBE_URL}" \
+    && KUBE_SHA="$(curl -fsSL "${KUBE_URL}.sha256")" \
+    && echo "${KUBE_SHA}  /usr/local/bin/kubectl" | sha256sum -c - \
+    && chmod 0755 /usr/local/bin/kubectl
+
+# Install coder CLI from upstream release tarball.
+# hadolint ignore=DL4006
+RUN ARCH="$(apk --print-arch)" \
+    && case "${ARCH}" in \
+         x86_64)  CODER_ARCH=amd64 ;; \
+         aarch64) CODER_ARCH=arm64 ;; \
+         *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;; \
+       esac \
+    && CODER_VER_NUM="${CODER_VERSION#v}" \
+    && curl -fsSL -o /tmp/coder.tar.gz \
+         "https://github.com/coder/coder/releases/download/${CODER_VERSION}/coder_${CODER_VER_NUM}_linux_${CODER_ARCH}.tar.gz" \
+    && tar -xzf /tmp/coder.tar.gz -C /tmp coder \
+    && mv /tmp/coder /usr/local/bin/coder \
+    && chmod 0755 /usr/local/bin/coder \
+    && rm -f /tmp/coder.tar.gz
+
+COPY assets/push-templates.sh assets/rotate-token.sh /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/push-templates.sh /usr/local/bin/rotate-token.sh
+
+USER coder
+WORKDIR /home/coder

--- a/coder-gitops/Dockerfile
+++ b/coder-gitops/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH="$(apk --print-arch)" \
     && CODER_VER_NUM="${CODER_VERSION#v}" \
     && curl -fsSL -o /tmp/coder.tar.gz \
          "https://github.com/coder/coder/releases/download/${CODER_VERSION}/coder_${CODER_VER_NUM}_linux_${CODER_ARCH}.tar.gz" \
-    && tar -xzf /tmp/coder.tar.gz -C /tmp coder \
+    && tar -xzf /tmp/coder.tar.gz -C /tmp ./coder \
     && mv /tmp/coder /usr/local/bin/coder \
     && chmod 0755 /usr/local/bin/coder \
     && rm -f /tmp/coder.tar.gz

--- a/coder-gitops/assets/push-templates.sh
+++ b/coder-gitops/assets/push-templates.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Push every Coder template under TEMPLATES_DIR (default /templates).
+# Iterates each subdir, runs `coder templates push <name> -y`, continues on
+# error, exits non-zero if any failed.
+#
+# Required env:
+#   CODER_URL            - Coder deployment URL (e.g. https://coder.example.com)
+#   CODER_SESSION_TOKEN  - Admin session token
+# Optional env:
+#   TEMPLATES_DIR        - Root dir containing one subdir per template (default /templates)
+
+set -uo pipefail
+
+: "${CODER_URL:?CODER_URL required}"
+: "${CODER_SESSION_TOKEN:?CODER_SESSION_TOKEN required}"
+TEMPLATES_DIR="${TEMPLATES_DIR:-/templates}"
+
+if [ ! -d "${TEMPLATES_DIR}" ]; then
+  echo "ERROR: TEMPLATES_DIR does not exist: ${TEMPLATES_DIR}" >&2
+  exit 1
+fi
+
+export CODER_URL CODER_SESSION_TOKEN
+
+failed=()
+pushed=()
+for dir in "${TEMPLATES_DIR}"/*/; do
+  [ -d "$dir" ] || continue
+  name="$(basename "$dir")"
+  echo "=== Pushing template: ${name} ==="
+  if coder templates push "${name}" --directory "${dir}" --yes; then
+    pushed+=("${name}")
+  else
+    echo "ERROR: push failed for ${name}" >&2
+    failed+=("${name}")
+  fi
+done
+
+echo
+echo "Pushed:  ${#pushed[@]} (${pushed[*]:-none})"
+echo "Failed:  ${#failed[@]} (${failed[*]:-none})"
+
+[ "${#failed[@]}" -eq 0 ]

--- a/coder-gitops/assets/rotate-token.sh
+++ b/coder-gitops/assets/rotate-token.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Rotate a Coder session token: mint a new token, patch a Kubernetes Secret
+# in-place with the new value, then revoke prior tokens with the same name
+# prefix.
+#
+# Required env:
+#   CODER_URL              - Coder deployment URL
+#   CODER_SESSION_TOKEN    - Admin session token (used to call the API)
+#   TOKEN_NAME_PREFIX      - Prefix for minted token names (e.g. "gitops")
+#   TOKEN_LIFETIME         - Lifetime accepted by `coder tokens create` (e.g. 720h)
+#   SECRET_NAME            - Kubernetes Secret to patch
+#   SECRET_NAMESPACE       - Namespace of the Secret
+#   SECRET_KEY             - Key inside the Secret to set (e.g. CODER_SESSION_TOKEN)
+
+set -euo pipefail
+
+: "${CODER_URL:?CODER_URL required}"
+: "${CODER_SESSION_TOKEN:?CODER_SESSION_TOKEN required}"
+: "${TOKEN_NAME_PREFIX:?TOKEN_NAME_PREFIX required}"
+: "${TOKEN_LIFETIME:?TOKEN_LIFETIME required}"
+: "${SECRET_NAME:?SECRET_NAME required}"
+: "${SECRET_NAMESPACE:?SECRET_NAMESPACE required}"
+: "${SECRET_KEY:?SECRET_KEY required}"
+
+export CODER_URL CODER_SESSION_TOKEN
+
+DATE_SUFFIX="$(date +%Y%m%d%H%M%S)"
+NEW_NAME="${TOKEN_NAME_PREFIX}-${DATE_SUFFIX}"
+
+echo "=== Coder session-token rotation ==="
+echo "Minting token: ${NEW_NAME} (lifetime=${TOKEN_LIFETIME})"
+
+NEW_TOKEN="$(coder tokens create --name "${NEW_NAME}" --lifetime "${TOKEN_LIFETIME}")"
+if [ -z "${NEW_TOKEN}" ]; then
+  echo "ERROR: coder tokens create returned empty value" >&2
+  exit 1
+fi
+
+echo "Patching secret ${SECRET_NAMESPACE}/${SECRET_NAME} key ${SECRET_KEY}"
+NEW_TOKEN_B64="$(printf '%s' "${NEW_TOKEN}" | base64 -w0)"
+kubectl patch secret "${SECRET_NAME}" -n "${SECRET_NAMESPACE}" \
+  --type='json' \
+  -p="[{\"op\":\"replace\",\"path\":\"/data/${SECRET_KEY}\",\"value\":\"${NEW_TOKEN_B64}\"}]"
+
+echo "Revoking prior tokens with prefix ${TOKEN_NAME_PREFIX}-"
+coder tokens list --output json |
+  jq -r ".[] | select(.token_name | startswith(\"${TOKEN_NAME_PREFIX}-\")) | select(.token_name != \"${NEW_NAME}\") | .token_name" |
+  while read -r OLD_NAME; do
+    echo "  removing: ${OLD_NAME}"
+    coder tokens remove "${OLD_NAME}" || echo "  WARN: failed to remove ${OLD_NAME}"
+  done
+
+echo "=== Rotation complete ==="

--- a/coder-gitops/metadata.yaml
+++ b/coder-gitops/metadata.yaml
@@ -1,0 +1,6 @@
+---
+# coder-gitops - Coder CLI + kubectl for GitOps-managed Coder
+# template sync and session-token rotation Jobs.
+
+version: "1.0"
+auto_patch: true

--- a/coder-gitops/test.sh
+++ b/coder-gitops/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Test coder-gitops image: required tooling, non-root user, scripts present,
+# read-only rootfs compatible.
+# Usage: ./test.sh <image-ref>
+
+set -euo pipefail
+
+IMAGE_REF="${1:?Usage: $0 <image-ref>}"
+
+echo "=== coder-gitops image tests ==="
+echo "Image: $IMAGE_REF"
+
+# Test 1: required binaries present
+echo "Test 1: required binaries..."
+for bin in coder kubectl curl jq bash; do
+  if ! docker run --rm --entrypoint sh "$IMAGE_REF" -c "command -v $bin >/dev/null"; then
+    echo "  ERROR: missing binary: $bin"
+    exit 1
+  fi
+  echo "  found: $bin"
+done
+
+# Test 2: runs as non-root UID 1000
+echo "Test 2: non-root user..."
+UID_OUT=$(docker run --rm --entrypoint id "$IMAGE_REF" -u)
+if [ "$UID_OUT" != "1000" ]; then
+  echo "  ERROR: expected UID 1000, got $UID_OUT"
+  exit 1
+fi
+echo "  UID=1000 ok"
+
+# Test 3: scripts present and executable
+echo "Test 3: scripts..."
+for script in push-templates.sh rotate-token.sh; do
+  if ! docker run --rm --entrypoint sh "$IMAGE_REF" -c "test -x /usr/local/bin/$script"; then
+    echo "  ERROR: /usr/local/bin/$script missing or not executable"
+    exit 1
+  fi
+  echo "  found: $script"
+done
+
+# Test 4: script syntax valid
+echo "Test 4: script syntax check..."
+for script in push-templates.sh rotate-token.sh; do
+  if ! docker run --rm --entrypoint bash "$IMAGE_REF" -n "/usr/local/bin/$script"; then
+    echo "  ERROR: $script has syntax errors"
+    exit 1
+  fi
+done
+echo "  syntax ok"
+
+# Test 5: kubectl + coder run (--client / --version)
+echo "Test 5: kubectl + coder version..."
+docker run --rm --entrypoint kubectl "$IMAGE_REF" version --client >/dev/null
+docker run --rm --entrypoint coder "$IMAGE_REF" version >/dev/null
+echo "  versions ok"
+
+# Test 6: read-only root filesystem compatible (PSA restricted)
+echo "Test 6: read-only rootfs + tmpfs /tmp..."
+if ! docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,size=16m \
+  --entrypoint sh "$IMAGE_REF" \
+  -c "kubectl version --client >/dev/null && coder version >/dev/null"; then
+  echo "  ERROR: binaries failed under read-only rootfs"
+  exit 1
+fi
+echo "  read-only rootfs ok"
+
+echo ""
+echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

- New `coder-gitops/` image: Alpine 3.23 + `coder` CLI (v2.31.9) + `kubectl` (v1.35.3) + curl, jq, bash
- Non-root UID 1000, PSA `restricted`-compatible (read-only rootfs, no runtime `apk add`)
- Two entrypoint scripts at `/usr/local/bin/`:
  - `push-templates.sh` — iterates `${TEMPLATES_DIR:-/templates}/*/`, runs `coder templates push`, continues on error, exits non-zero if any failed
  - `rotate-token.sh` — mints token, patches Secret in-place, revokes prior tokens with same prefix
- Renovate annotations for both `CODER_VERSION` and `KUBECTL_VERSION`

## Test plan

- [ ] CI build passes
- [ ] `test.sh` validates: required binaries, UID=1000, scripts present + syntax-clean, kubectl/coder versions work, read-only rootfs compatible
- [ ] Trivy scan passes
- [ ] Consumer (spruyt-labs #934) pins published `<TAG>@sha256:<digest>`

Closes #458