### PR TITLE
fix(coder-gitops): revoke prior tokens by id, not name

### DIFF
--- a/coder-gitops/assets/rotate-token.sh
+++ b/coder-gitops/assets/rotate-token.sh
@@ -44,10 +44,10 @@ kubectl patch secret "${SECRET_NAME}" -n "${SECRET_NAMESPACE}" \
 
 echo "Revoking prior tokens with prefix ${TOKEN_NAME_PREFIX}-"
 coder tokens list --output json |
-  jq -r ".[] | select(.token_name | startswith(\"${TOKEN_NAME_PREFIX}-\")) | select(.token_name != \"${NEW_NAME}\") | .token_name" |
-  while read -r OLD_NAME; do
-    echo "  removing: ${OLD_NAME}"
-    coder tokens remove "${OLD_NAME}" || echo "  WARN: failed to remove ${OLD_NAME}"
+  jq -r ".[] | select(.token_name | startswith(\"${TOKEN_NAME_PREFIX}-\")) | select(.token_name != \"${NEW_NAME}\") | \"\(.id) \(.token_name)\"" |
+  while read -r OLD_ID OLD_NAME; do
+    echo "  removing: ${OLD_NAME} (${OLD_ID})"
+    coder tokens remove "${OLD_ID}" || echo "  WARN: failed to remove ${OLD_NAME} (${OLD_ID})"
   done
 
 echo "=== Rotation complete ==="


### PR DESCRIPTION
## Summary
- `coder tokens remove <name>` can silently no-op under client/server version skew or permission boundaries.
- Select `.id` from listing; pass id to remove. Name retained in log output.

Closes #462

## Test plan
- [ ] CI build + test.sh pass
- [ ] Deploy new image in homelab; confirm prior tokens revoked each rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)