### PR TITLE
fix(ci): fetch full history and tags for release changelog

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -237,6 +237,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Free up disk space
         run: |
@@ -457,6 +460,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Log in to GHCR (read-only)
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121


### PR DESCRIPTION
## Summary
- Build and missing-release jobs in `_image-pipeline.yaml` did shallow checkouts without tags
- `git log <prev_tag>..HEAD` in `create-release.sh` silently returned empty, so release notes always said "Rebuild (no source changes)" or "Initial release"
- Added `fetch-depth: 0` + `fetch-tags: true` to both checkouts

## Test plan
- [ ] Next push to main produces release notes with actual commit list under `### Changes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)