### PR TITLE
feat(devcontainer-common): add podman, safe-chain, agent-run, post-create

### DIFF
--- a/devcontainer-common/.trivyignore
+++ b/devcontainer-common/.trivyignore
@@ -22,6 +22,18 @@ CVE-2026-33671
 CVE-2026-33810
 CVE-2026-35535
 
+# safe-chain local MITM CA key (generated at build time for supply-chain protection)
+private-key
+
+# Transitive npm deps in safe-chain (upstream)
+CVE-2026-25547
+CVE-2026-26996
+CVE-2026-33891
+CVE-2026-33894
+CVE-2026-33895
+CVE-2026-33896
+CVE-2026-4800
+
 # Go stdlib CVEs in gh-cli binary
 CVE-2023-39321
 CVE-2023-39322

--- a/devcontainer-common/Dockerfile
+++ b/devcontainer-common/Dockerfile
@@ -3,9 +3,8 @@ FROM mcr.microsoft.com/devcontainers/base:jammy@sha256:0e50c6443341c5302ad472804
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::http::Pipeline-Depth "0";\nAcquire::Retries::Delay::Maximum "10";\n' \
-    > /etc/apt/apt.conf.d/80-retries
-
-RUN apt-get update && apt-get install -y --no-install-recommends jq \
+    > /etc/apt/apt.conf.d/80-retries \
+    && apt-get update && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://raw.githubusercontent.com/MilkClouds/devcontainer-feature-installer/main/install-feature-cli.sh | bash
 
@@ -14,14 +13,14 @@ RUN feature-install --features "$(jq -c '.features' /tmp/devcontainer.json)" \
     && rm /tmp/devcontainer.json
 
 COPY assets/scripts/ /tmp/scripts/
-RUN chmod +x /tmp/scripts/*.sh
 
 ENV NVM_DIR="/usr/local/share/nvm"
 ENV PATH="/usr/local/py-utils/bin:/usr/local/share/nvm/current/bin:/usr/local/python/current/bin:$PATH"
 
 # renovate: datasource=npm depName=@aikidosec/safe-chain
 ARG SAFE_CHAIN_VERSION="1.4.9"
-RUN SAFE_CHAIN_VERSION="${SAFE_CHAIN_VERSION}" /tmp/scripts/install-safe-chain.sh
+RUN chmod +x /tmp/scripts/*.sh \
+    && SAFE_CHAIN_VERSION="${SAFE_CHAIN_VERSION}" /tmp/scripts/install-safe-chain.sh
 
 ENV PATH="/root/.safe-chain/shims:$PATH"
 
@@ -44,9 +43,8 @@ RUN export PIPX_HOME="/usr/local/py-utils" \
 # Policy-enforcing podman wrapper + runtime post-create script
 COPY assets/agent-run /usr/local/bin/agent-run
 COPY assets/post-create.sh /usr/local/bin/devcontainer-post-create
-RUN chmod 755 /usr/local/bin/agent-run /usr/local/bin/devcontainer-post-create
-
-RUN rm -rf /tmp/scripts
+RUN chmod 755 /usr/local/bin/agent-run /usr/local/bin/devcontainer-post-create \
+    && rm -rf /tmp/scripts
 
 HEALTHCHECK NONE
 

--- a/devcontainer-common/Dockerfile
+++ b/devcontainer-common/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/devcontainers/base:jammy@sha256:0e50c6443341c5302ad472804
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::http::Pipeline-Depth "0";\nAcquire::Retries::Delay::Maximum "10";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://raw.githubusercontent.com/MilkClouds/devcontainer-feature-installer/main/install-feature-cli.sh | bash
@@ -10,8 +13,23 @@ COPY assets/.devcontainer.json /tmp/devcontainer.json
 RUN feature-install --features "$(jq -c '.features' /tmp/devcontainer.json)" \
     && rm /tmp/devcontainer.json
 
+COPY assets/scripts/ /tmp/scripts/
+RUN chmod +x /tmp/scripts/*.sh
+
 ENV NVM_DIR="/usr/local/share/nvm"
 ENV PATH="/usr/local/py-utils/bin:/usr/local/share/nvm/current/bin:/usr/local/python/current/bin:$PATH"
+
+# renovate: datasource=npm depName=@aikidosec/safe-chain
+ARG SAFE_CHAIN_VERSION="1.4.9"
+RUN SAFE_CHAIN_VERSION="${SAFE_CHAIN_VERSION}" /tmp/scripts/install-safe-chain.sh
+
+ENV PATH="/root/.safe-chain/shims:$PATH"
+
+# Run remaining install scripts (safe-chain shims protect npm/pip)
+RUN for script in /tmp/scripts/install-*.sh; do \
+      [ "$(basename "$script")" = "install-safe-chain.sh" ] && continue; \
+      echo "Running $script..." && "$script"; \
+    done
 
 # renovate: datasource=pypi depName=pre-commit
 ARG PRE_COMMIT_VERSION="4.5.1"
@@ -23,6 +41,16 @@ RUN export PIPX_HOME="/usr/local/py-utils" \
     && pip install --no-cache-dir "pipx==${PIPX_VERSION}" \
     && pipx install "pre-commit==${PRE_COMMIT_VERSION}"
 
+# Policy-enforcing podman wrapper + runtime post-create script
+COPY assets/agent-run /usr/local/bin/agent-run
+COPY assets/post-create.sh /usr/local/bin/devcontainer-post-create
+RUN chmod 755 /usr/local/bin/agent-run /usr/local/bin/devcontainer-post-create
+
+RUN rm -rf /tmp/scripts
+
 HEALTHCHECK NONE
 
 USER vscode
+
+RUN safe-chain setup && safe-chain setup-ci
+ENV PATH="/home/vscode/.safe-chain/shims:$PATH"

--- a/devcontainer-common/assets/agent-run
+++ b/devcontainer-common/assets/agent-run
@@ -1,0 +1,147 @@
+#!/bin/bash
+# agent-run: policy-enforcing wrapper around `podman run` for AI agents.
+#
+# Enforces safe defaults for images pulled and executed by agents:
+#   - rootless userns mapping (--userns=auto)
+#   - read-only root filesystem with /tmp + /var/tmp tmpfs
+#   - no-new-privileges, all capabilities dropped
+#   - pids/memory/cpu limits to contain runaway workloads
+#   - slirp4netns without host loopback by default
+#
+# Forbidden user args are rejected before podman is invoked. This is not a
+# security boundary (a determined agent can bypass by calling podman directly);
+# it is a guardrail that makes the safe path the easy path. Real isolation
+# comes from rootless podman + (phase 2) Kata runtime on the Coder pod.
+#
+# Usage:
+#   agent-run [podman-run-args...] IMAGE [CMD...]
+
+set -euo pipefail
+
+# Hard-rejected flags. Also catches `--flag=true` and `--flag=value` variants
+# via prefix match, and space-separated `--flag value` via the look-ahead below.
+readonly FORBIDDEN_FLAGS=(
+  --privileged
+  --pid
+  --network
+  --ipc
+  --uts
+  --userns
+  --cgroupns
+  --cap-add
+)
+
+# Rejected substring patterns (matched anywhere in an arg). These are values
+# that are unsafe in any flag context (e.g. mounting the docker socket).
+readonly FORBIDDEN_SUBSTR=(
+  "seccomp=unconfined"
+  "apparmor=unconfined"
+  "label=disable"
+  "/var/run/docker.sock"
+  "/run/docker.sock"
+  "/run/podman/podman.sock"
+)
+
+# Values that make a namespace/privilege-related flag dangerous.
+readonly FORBIDDEN_VALUES=(
+  host
+  true
+  ALL
+  all
+)
+
+is_forbidden_flag() {
+  local f="$1"
+  for flag in "${FORBIDDEN_FLAGS[@]}"; do
+    [[ "$f" == "$flag" ]] && return 0
+  done
+  return 1
+}
+
+is_forbidden_value() {
+  local v="$1"
+  for val in "${FORBIDDEN_VALUES[@]}"; do
+    [[ "$v" == "$val" ]] && return 0
+  done
+  return 1
+}
+
+# --privileged with no value is always forbidden.
+# For flags with a value: reject if value ∈ FORBIDDEN_VALUES.
+i=1
+while [[ $i -le $# ]]; do
+  arg="${!i}"
+
+  for pat in "${FORBIDDEN_SUBSTR[@]}"; do
+    if [[ "$arg" == *"$pat"* ]]; then
+      echo "agent-run: forbidden pattern in arg: $arg (matched: $pat)" >&2
+      exit 64
+    fi
+  done
+
+  # Bare --privileged (no value).
+  if [[ "$arg" == "--privileged" ]]; then
+    echo "agent-run: forbidden flag: --privileged" >&2
+    exit 64
+  fi
+
+  # --flag=value form.
+  if [[ "$arg" == *=* ]]; then
+    flag="${arg%%=*}"
+    value="${arg#*=}"
+    if is_forbidden_flag "$flag" && is_forbidden_value "$value"; then
+      echo "agent-run: forbidden flag=value: $arg" >&2
+      exit 64
+    fi
+  # --flag value form (space-separated).
+  elif is_forbidden_flag "$arg"; then
+    next_i=$((i + 1))
+    if [[ $next_i -le $# ]]; then
+      next="${!next_i}"
+      if is_forbidden_value "$next"; then
+        echo "agent-run: forbidden flag+value: $arg $next" >&2
+        exit 64
+      fi
+    fi
+  fi
+
+  i=$((i + 1))
+done
+
+# Policy defaults. Override via AGENT_RUN_* env vars where sensible.
+AGENT_NET="${AGENT_RUN_NET:-slirp4netns:allow_host_loopback=false}"
+AGENT_MEM="${AGENT_RUN_MEM:-2g}"
+AGENT_PIDS="${AGENT_RUN_PIDS:-512}"
+AGENT_CPUS="${AGENT_RUN_CPUS:-2}"
+
+# Rootless podman is preferred. In WSL2 nested userns, newuidmap fails because
+# the outer namespace did not delegate subuid ranges; fall back to `sudo podman`
+# with --network=host --uts=host (matching lint.sh). Cgroups are also unavailable
+# in WSL2 devcontainers, so resource limits must be skipped.
+runner=(podman)
+ns_args=(--userns=auto)
+limit_args=(
+  --pids-limit="$AGENT_PIDS"
+  --memory="$AGENT_MEM"
+  --memory-swap="$AGENT_MEM"
+  --cpus="$AGENT_CPUS"
+)
+if ! podman info >/dev/null 2>&1; then
+  if [[ "$(id -u)" != "0" ]] && command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    runner=(sudo -n podman)
+    AGENT_NET="host"
+    ns_args=(--uts=host)
+    limit_args=()
+  fi
+fi
+
+exec "${runner[@]}" run --rm \
+  "${ns_args[@]}" \
+  --read-only \
+  --tmpfs /tmp:rw,exec,nosuid,nodev,size=256m \
+  --tmpfs /var/tmp:rw,exec,nosuid,nodev,size=64m \
+  --security-opt no-new-privileges \
+  --cap-drop=ALL \
+  "${limit_args[@]}" \
+  --network="$AGENT_NET" \
+  "$@"

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+set -euo pipefail
+
+# devcontainer-post-create: runtime setup for devcontainer-common based images.
+# Packages (podman, safe-chain, pre-commit, gh, node, python) are pre-installed.
+# This script handles runtime configuration that requires workspace context.
+#
+# Usage: devcontainer-post-create [workspace-dir]
+
+WORKSPACE="${1:-.}"
+DEVCONTAINER_DIR="$WORKSPACE/.devcontainer"
+
+PASSED=0
+FAILED=0
+pass() {
+  echo "✓ $1"
+  PASSED=$((PASSED + 1))
+}
+fail() {
+  echo "✗ $1"
+  FAILED=$((FAILED + 1))
+}
+
+# --- Runtime Configuration ---
+
+git config --global --add safe.directory '*'
+
+sudo mkdir -p /etc/containers/registries.conf.d /etc/containers/containers.conf.d
+sudo chmod a+rx /etc/containers /etc/containers/registries.conf.d /etc/containers/containers.conf.d
+
+git ls-files -z '*.sh' | xargs -0 -r chmod +x 2>/dev/null || true
+
+echo "Setting up safe-chain..."
+safe-chain setup
+safe-chain setup-ci
+export PATH="$HOME/.safe-chain/shims:$PATH"
+
+echo "Installing pre-commit hooks..."
+git config --unset-all core.hooksPath 2>/dev/null || true
+pre-commit install --install-hooks
+
+echo "Installing Claude Code CLI..."
+curl -fsSL https://claude.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+# shellcheck disable=SC2016
+grep -q 'local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$HOME/.bashrc"
+
+# Podman userns config
+mkdir -p "$HOME/.config/containers/containers.conf.d"
+cat >"$HOME/.config/containers/containers.conf.d/10-userns.conf" <<'CONTAINERS_CONF'
+[containers]
+userns = "keep-id"
+CONTAINERS_CONF
+
+# Storage and cgroup configuration (Kata vs WSL2 detection)
+if [ -b /dev/containers-disk ]; then
+  if ! sudo blkid /dev/containers-disk >/dev/null 2>&1; then
+    sudo mkfs.ext4 -q -L containers /dev/containers-disk
+  fi
+  sudo mkdir -p /var/lib/containers
+  sudo mountpoint -q /var/lib/containers || sudo mount -o noatime /dev/containers-disk /var/lib/containers
+  rm -rf "$HOME/.local/share/containers/storage" "$HOME/.config/containers/storage.conf"
+  sudo mkdir -p /etc/containers
+  sudo tee /etc/containers/storage.conf >/dev/null <<'ROOTFUL_STORAGE_CONF'
+[storage]
+driver = "overlay"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+ROOTFUL_STORAGE_CONF
+  sudo tee /etc/containers/containers.conf >/dev/null <<'CONTAINERS_CONF'
+[containers]
+cgroups = "disabled"
+
+[engine]
+cgroup_manager = "cgroupfs"
+CONTAINERS_CONF
+  grep -q 'alias podman=' "$HOME/.bashrc" 2>/dev/null || echo 'alias podman="sudo podman"' >>"$HOME/.bashrc"
+else
+  sudo mkdir -p /etc/containers
+  sudo tee /etc/containers/storage.conf >/dev/null <<'ROOTFUL_STORAGE_CONF'
+[storage]
+driver = "overlay"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+ROOTFUL_STORAGE_CONF
+  sudo tee /etc/containers/containers.conf >/dev/null <<'CONTAINERS_CONF'
+[containers]
+cgroups = "disabled"
+
+[engine]
+cgroup_manager = "cgroupfs"
+CONTAINERS_CONF
+  sudo chown root:root /var/lib/containers
+  mkdir -p "$HOME/.config/containers"
+  cat >"$HOME/.config/containers/storage.conf" <<STORAGE_CONF
+[storage]
+driver = "overlay"
+runroot = "/run/user/$(id -u)/containers"
+graphroot = "$HOME/.local/share/containers/storage"
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"
+STORAGE_CONF
+  grep -q 'alias podman=' "$HOME/.bashrc" 2>/dev/null || echo 'alias podman="sudo podman"' >>"$HOME/.bashrc"
+fi
+
+# Registry allow-list
+mkdir -p "$HOME/.config/containers/registries.conf.d"
+cat >"$HOME/.config/containers/registries.conf.d/10-allow-list.conf" <<'REGISTRIES_CONF'
+unqualified-search-registries = []
+short-name-mode = "enforcing"
+
+[[registry]]
+location = "docker.io"
+
+[[registry]]
+location = "ghcr.io"
+
+[[registry]]
+location = "quay.io"
+
+[[registry]]
+location = "registry.k8s.io"
+
+[[registry]]
+location = "mcr.microsoft.com"
+REGISTRIES_CONF
+
+echo ""
+echo "Setting up devcontainer (repo-specific tooling)..."
+if [[ -x "$DEVCONTAINER_DIR/setup-devcontainer.sh" ]]; then
+  "$DEVCONTAINER_DIR/setup-devcontainer.sh"
+else
+  echo "  No setup-devcontainer.sh found, skipping"
+fi
+
+echo "Running devcontainer verification tests..."
+echo ""
+
+# --- Verification Tests ---
+
+if ! docker --version 2>&1 | grep -qi 'podman'; then
+  fail "docker CLI is not Podman (got: $(docker --version 2>&1))"
+elif sudo -n docker run --rm docker.io/library/hello-world &>/dev/null; then
+  pass "Rootful Podman is working (docker → podman)"
+else
+  echo "  SKIP: Podman not runnable yet (may start via agent script in Coder)"
+fi
+
+if pre-commit --version &>/dev/null; then
+  pass "Pre-commit is installed"
+else
+  fail "Pre-commit is not installed"
+fi
+
+SAFE_NPM="$HOME/.safe-chain/shims/npm"
+if [[ -x "$SAFE_NPM" ]]; then
+  TEMP_DIR=$(mktemp -d)
+  SAFE_OUTPUT=$(cd "$TEMP_DIR" && "$SAFE_NPM" install safe-chain-test 2>&1 || true)
+  rm -rf "$TEMP_DIR"
+  if echo "$SAFE_OUTPUT" | grep -qi "safe-chain"; then
+    pass "Safe-chain is blocking malicious packages"
+  else
+    fail "Safe-chain is not blocking (check output: $SAFE_OUTPUT)"
+  fi
+else
+  fail "Safe-chain shims not found at $SAFE_NPM"
+fi
+
+if command -v gh &>/dev/null; then
+  pass "GitHub CLI is installed"
+else
+  fail "GitHub CLI is not installed"
+fi
+
+SSH_AGENT_OK=false
+if [[ -S "${SSH_AUTH_SOCK:-}" ]]; then
+  ssh_rc=0
+  SSH_ASKPASS='' ssh-add -l &>/dev/null || ssh_rc=$?
+  [[ $ssh_rc -ne 2 ]] && SSH_AGENT_OK=true
+fi
+if $SSH_AGENT_OK; then
+  pass "SSH agent reachable ($SSH_AUTH_SOCK)"
+elif [[ -f "/etc/coder/ssh-keys/id_ed25519" ]]; then
+  pass "SSH key mounted (Coder direct mount)"
+elif [[ -n "${GIT_SSH_COMMAND:-}" ]]; then
+  pass "GIT_SSH_COMMAND configured"
+else
+  echo "  SKIP: No SSH key configured"
+fi
+
+if command -v claude &>/dev/null; then
+  pass "Claude Code CLI is installed"
+else
+  fail "Claude Code CLI is not installed"
+fi
+
+if [[ -x /usr/local/bin/agent-run ]]; then
+  agent_run_out=$(/usr/local/bin/agent-run --privileged alpine true 2>&1 || true)
+  if echo "$agent_run_out" | grep -q 'forbidden flag'; then
+    pass "agent-run wrapper installed and enforcing policy"
+  else
+    fail "agent-run wrapper installed but not enforcing --privileged rejection"
+  fi
+else
+  fail "agent-run wrapper not installed"
+fi
+
+if command -v podman &>/dev/null; then
+  graph_driver=$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || echo "unknown")
+  if [[ "$graph_driver" == "overlay" ]]; then
+    pass "Podman storage driver is overlay"
+  else
+    echo "  SKIP: Podman graph driver is '$graph_driver' (expected 'overlay')"
+  fi
+else
+  fail "Podman not installed"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+
+if [[ $FAILED -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/devcontainer-common/assets/scripts/install-podman.sh
+++ b/devcontainer-common/assets/scripts/install-podman.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+apt-get remove -y --purge moby-cli moby-engine moby-buildx moby-compose \
+  moby-containerd moby-runc docker-ce-cli docker-ce 2>/dev/null || true
+
+apt-get update && apt-get install -y --no-install-recommends \
+  podman \
+  podman-docker \
+  fuse-overlayfs \
+  uidmap \
+  slirp4netns
+
+rm -rf /var/lib/apt/lists/*
+
+mkdir -p /etc/containers
+touch /etc/containers/nodocker
+
+echo "vscode:100000:65536" >>/etc/subuid
+echo "vscode:100000:65536" >>/etc/subgid
+
+echo "podman installed with rootless support"

--- a/devcontainer-common/assets/scripts/install-safe-chain.sh
+++ b/devcontainer-common/assets/scripts/install-safe-chain.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION:?SAFE_CHAIN_VERSION must be set}"
+safe-chain setup
+safe-chain setup-ci
+
+echo "safe-chain ${SAFE_CHAIN_VERSION} installed and configured"

--- a/devcontainer-common/metadata.yaml
+++ b/devcontainer-common/metadata.yaml
@@ -1,3 +1,3 @@
 ---
-version: "1.0"
+version: "1.1"
 auto_patch: true

--- a/devcontainer-common/test.sh
+++ b/devcontainer-common/test.sh
@@ -9,7 +9,14 @@ docker run --rm "$IMAGE_REF" bash -c '
   node --version &&
   python3 --version &&
   pre-commit --version &&
-  gh --version
+  gh --version &&
+  echo "=== Podman ===" &&
+  command -v podman &&
+  echo "=== Safe-chain ===" &&
+  command -v safe-chain &&
+  echo "=== Scripts ===" &&
+  test -x /usr/local/bin/agent-run && echo "agent-run: OK" &&
+  test -x /usr/local/bin/devcontainer-post-create && echo "devcontainer-post-create: OK"
 '
 
 echo "All tests passed!"


### PR DESCRIPTION
## Summary

- Pre-install podman stack (podman-docker, fuse-overlayfs, uidmap, slirp4netns) and safe-chain at build time
- Ship `agent-run` policy wrapper and `devcontainer-post-create` runtime script in the image
- Downstream repos call `devcontainer-post-create` from postCreateCommand and only need `setup-devcontainer.sh`
- Follows gastown-dev `assets/scripts/` pattern for install scripts
- Version bump to 1.1 (auto_patch produces 1.1.0)

## What moves into the image

| Component | Before | After |
|-----------|--------|-------|
| Podman + deps | post-create.sh (runtime) | Dockerfile (build) |
| safe-chain | post-create.sh (runtime) | Dockerfile (build, pinned) |
| agent-run | post-create.sh copies to /usr/local/bin | COPY in Dockerfile |
| post-create.sh | repo-operator syncs to every repo | Ships in image at `/usr/local/bin/devcontainer-post-create` |

## What repo-operator still syncs ("basic")

- `initialize.sh` (host-side SSH setup, runs before container)
- `podman-seccomp.json` + `update-podman-seccomp.sh` (host-side seccomp profile)
- `setup-devcontainer.sh` (repo-specific)

## Test plan

- [x] Local build passes (`sudo podman build --format docker`)
- [x] CI test verifies node, python, pre-commit, gh, podman, safe-chain, agent-run, devcontainer-post-create
- [x] Trivy scan clean (safe-chain CA key + transitive npm CVEs in .trivyignore)
- [ ] CI pipeline builds and releases 1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)