### PR TITLE
refactor(devcontainer-common): move safe-chain from build-time to post-create

### DIFF
--- a/devcontainer-common/.trivyignore
+++ b/devcontainer-common/.trivyignore
@@ -22,18 +22,6 @@ CVE-2026-33671
 CVE-2026-33810
 CVE-2026-35535
 
-# safe-chain local MITM CA key (generated at build time for supply-chain protection)
-private-key
-
-# Transitive npm deps in safe-chain (upstream)
-CVE-2026-25547
-CVE-2026-26996
-CVE-2026-33891
-CVE-2026-33894
-CVE-2026-33895
-CVE-2026-33896
-CVE-2026-4800
-
 # Go stdlib CVEs in gh-cli binary
 CVE-2023-39321
 CVE-2023-39322

--- a/devcontainer-common/Dockerfile
+++ b/devcontainer-common/Dockerfile
@@ -17,18 +17,10 @@ COPY assets/scripts/ /tmp/scripts/
 ENV NVM_DIR="/usr/local/share/nvm"
 ENV PATH="/usr/local/py-utils/bin:/usr/local/share/nvm/current/bin:/usr/local/python/current/bin:$PATH"
 
-# renovate: datasource=npm depName=@aikidosec/safe-chain
-ARG SAFE_CHAIN_VERSION="1.4.9"
 RUN chmod +x /tmp/scripts/*.sh \
-    && SAFE_CHAIN_VERSION="${SAFE_CHAIN_VERSION}" /tmp/scripts/install-safe-chain.sh
-
-ENV PATH="/root/.safe-chain/shims:$PATH"
-
-# Run remaining install scripts (safe-chain shims protect npm/pip)
-RUN for script in /tmp/scripts/install-*.sh; do \
-      [ "$(basename "$script")" = "install-safe-chain.sh" ] && continue; \
-      echo "Running $script..." && "$script"; \
-    done
+    && for script in /tmp/scripts/install-*.sh; do \
+         echo "Running $script..." && "$script"; \
+       done
 
 # renovate: datasource=pypi depName=pre-commit
 ARG PRE_COMMIT_VERSION="4.5.1"
@@ -49,6 +41,3 @@ RUN chmod 755 /usr/local/bin/agent-run /usr/local/bin/devcontainer-post-create \
 HEALTHCHECK NONE
 
 USER vscode
-
-RUN safe-chain setup && safe-chain setup-ci
-ENV PATH="/home/vscode/.safe-chain/shims:$PATH"

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # devcontainer-post-create: runtime setup for devcontainer-common based images.
-# Packages (podman, safe-chain, pre-commit, gh, node, python) are pre-installed.
+# Packages (podman, pre-commit, gh, node, python) are pre-installed.
 # This script handles runtime configuration that requires workspace context.
 #
 # Usage: devcontainer-post-create [workspace-dir]
@@ -30,7 +30,10 @@ sudo chmod a+rx /etc/containers /etc/containers/registries.conf.d /etc/container
 
 git ls-files -z '*.sh' | xargs -0 -r chmod +x 2>/dev/null || true
 
-echo "Setting up safe-chain..."
+# renovate: datasource=npm depName=@aikidosec/safe-chain
+SAFE_CHAIN_VERSION="1.4.9"
+echo "Installing safe-chain ${SAFE_CHAIN_VERSION}..."
+npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION}"
 safe-chain setup
 safe-chain setup-ci
 export PATH="$HOME/.safe-chain/shims:$PATH"

--- a/devcontainer-common/assets/scripts/install-safe-chain.sh
+++ b/devcontainer-common/assets/scripts/install-safe-chain.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION:?SAFE_CHAIN_VERSION must be set}"
-safe-chain setup
-safe-chain setup-ci
-
-echo "safe-chain ${SAFE_CHAIN_VERSION} installed and configured"

--- a/devcontainer-common/test.sh
+++ b/devcontainer-common/test.sh
@@ -12,8 +12,6 @@ docker run --rm "$IMAGE_REF" bash -c '
   gh --version &&
   echo "=== Podman ===" &&
   command -v podman &&
-  echo "=== Safe-chain ===" &&
-  command -v safe-chain &&
   echo "=== Scripts ===" &&
   test -x /usr/local/bin/agent-run && echo "agent-run: OK" &&
   test -x /usr/local/bin/devcontainer-post-create && echo "devcontainer-post-create: OK"


### PR DESCRIPTION
## Summary

- Remove safe-chain installation and PATH shims from devcontainer-common Dockerfile
- Move safe-chain install (`npm install -g`) into `devcontainer-post-create` runtime script
- Delete `install-safe-chain.sh` build script (no longer needed)

Safe-chain's npm shims baked into the image `ENV PATH` intercept all npm calls in layers built on top — including devcontainer feature installs via nanolayer. For large packages like renovate, this adds enough overhead to crash WSL2. Moving safe-chain to runtime keeps the image clean for downstream feature layering while preserving supply-chain protection at dev time.

## Test plan

- [ ] CI builds devcontainer-common image successfully
- [ ] Rebuild local devcontainer — verify safe-chain installs during post-create
- [ ] Verify `safe-chain` shims are active after container creation
- [ ] Verify devcontainer features can layer on top without WSL2 crash