### PR TITLE
fix(claude-agent): add openssh-client for git SSH operations

### DIFF
--- a/claude-agent/Dockerfile
+++ b/claude-agent/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates curl git jq python3 python3-pip \
+  ca-certificates curl git openssh-client jq python3 python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
 # Aikido safe-chain (installed globally, then set up for node user)


### PR DESCRIPTION
## Problem

`git clone` via SSH fails in the claude-agent container because `openssh-client` is not installed. The Dockerfile uses `--no-install-recommends` which skips it as a git dependency.

## Error

```
ssh -i /etc/git-ssh/id_ed25519 -o StrictHostKeyChecking=no: 1: ssh: not found
fatal: Could not read from remote repository.
```

## Fix

Add `openssh-client` to the `apt-get install` line in the claude-agent Dockerfile so that the `ssh` binary is available for git SSH operations (clone, push, fetch).

Closes #479