### PR TITLE
feat(devcontainer-common): add mdformat-frontmatter plugin

### DIFF
--- a/devcontainer-common/Dockerfile
+++ b/devcontainer-common/Dockerfile
@@ -36,9 +36,12 @@ RUN export PIPX_HOME="/usr/local/py-utils" \
 ARG MDFORMAT_VERSION="1.0.0"
 # renovate: datasource=pypi depName=mdformat-gfm
 ARG MDFORMAT_GFM_VERSION="1.0.0"
+# renovate: datasource=pypi depName=mdformat-frontmatter
+ARG MDFORMAT_FRONTMATTER_VERSION="2.0.10"
 RUN pip install --no-cache-dir \
     "mdformat==${MDFORMAT_VERSION}" \
-    "mdformat-gfm==${MDFORMAT_GFM_VERSION}"
+    "mdformat-gfm==${MDFORMAT_GFM_VERSION}" \
+    "mdformat-frontmatter==${MDFORMAT_FRONTMATTER_VERSION}"
 
 # Policy-enforcing podman wrapper + runtime post-create script
 COPY assets/agent-run /usr/local/bin/agent-run

--- a/devcontainer-common/test.sh
+++ b/devcontainer-common/test.sh
@@ -10,6 +10,7 @@ docker run --rm "$IMAGE_REF" bash -c '
   python3 --version &&
   pre-commit --version &&
   mdformat --version &&
+  pip show mdformat-frontmatter &&
   gh --version &&
   echo "=== Podman ===" &&
   command -v podman &&


### PR DESCRIPTION
## Summary

- Add `mdformat-frontmatter` v2.0.10 to devcontainer base image pip install
- Add Renovate annotation for automatic version tracking
- Add `pip show mdformat-frontmatter` check to test.sh

Closes #488

## Test plan

- [ ] CI builds image successfully
- [ ] test.sh confirms mdformat-frontmatter is installed
- [ ] mdformat correctly handles files with YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)