### PR TITLE
fix(ci): replace container retention policy to fix multi-arch image deletion

### DIFF
--- a/.github/workflows/container-retention.yaml
+++ b/.github/workflows/container-retention.yaml
@@ -17,13 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          account: user
           token: ${{ secrets.CONTAINER_RETENTION_TOKEN }}
-          image-names: "megalinter-*"
-          cut-off: 4w
-          keep-n-most-recent: 5
+          package: megalinter-*
+          expand-packages: true
+          older-than: 4 weeks
+          keep-n-tagged: 5
+          delete-ghost-images: true
+          delete-partial-images: true
           dry-run: ${{ inputs.dry_run || 'false' }}
 
   cleanup-releases:


### PR DESCRIPTION
## Summary

- Replace `snok/container-retention-policy` with `dataaxiom/ghcr-cleanup-action` (v1.0.16, SHA-pinned)
- snok action deletes untagged platform manifests that tagged multi-arch images depend on, breaking `docker pull` (upstream bugs #97, #90, #63 — all unfixed)
- dataaxiom action maps manifest descriptors and skips referenced platform manifests, making it multi-arch safe
- Added `delete-ghost-images` and `delete-partial-images` for cleaning up broken multi-arch images

Closes #509

## Test plan

- [ ] Trigger workflow_dispatch with `dry_run: true` and verify output shows correct packages selected
- [ ] Verify no platform manifests of tagged multi-arch images appear in deletion list
- [ ] Run with `dry_run: false` and confirm `docker pull` still works for all tagged megalinter images

🤖 Generated with [Claude Code](https://claude.com/claude-code)