### PR TITLE
feat(coder-gitops): diff-based template push — skip unchanged templates

### DIFF
--- a/coder-gitops/assets/push-templates.sh
+++ b/coder-gitops/assets/push-templates.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Push every Coder template under TEMPLATES_DIR (default /templates).
-# Iterates each subdir, runs `coder templates push <name> -y`, continues on
-# error, exits non-zero if any failed.
+# Diff-based Coder template push. For each subdir in TEMPLATES_DIR, pulls the
+# active version from Coder, diffs against local files, and only pushes when
+# content differs. New templates (pull fails) are always pushed.
 #
 # Required env:
 #   CODER_URL            - Coder deployment URL (e.g. https://coder.example.com)
@@ -24,10 +24,29 @@ export CODER_URL CODER_SESSION_TOKEN
 
 failed=()
 pushed=()
+skipped=()
 for dir in "${TEMPLATES_DIR}"/*/; do
   [ -d "$dir" ] || continue
   name="$(basename "$dir")"
-  echo "=== Pushing template: ${name} ==="
+
+  echo "=== Checking template: ${name} ==="
+
+  pull_dir="$(mktemp -d)"
+
+  if coder templates pull "${name}" "${pull_dir}" 2>/dev/null; then
+    if diff -rq "${dir}" "${pull_dir}" >/dev/null 2>&1; then
+      echo "SKIP: ${name} — no changes detected"
+      skipped+=("${name}")
+      rm -rf "${pull_dir}"
+      continue
+    fi
+    echo "CHANGED: ${name} — pushing new version"
+  else
+    echo "NEW: ${name} — template does not exist yet, creating"
+  fi
+
+  rm -rf "${pull_dir}"
+
   if coder templates push "${name}" --directory "${dir}" --yes; then
     pushed+=("${name}")
   else
@@ -38,6 +57,7 @@ done
 
 echo
 echo "Pushed:  ${#pushed[@]} (${pushed[*]:-none})"
+echo "Skipped: ${#skipped[@]} (${skipped[*]:-none})"
 echo "Failed:  ${#failed[@]} (${failed[*]:-none})"
 
 [ "${#failed[@]}" -eq 0 ]

--- a/coder-gitops/test.sh
+++ b/coder-gitops/test.sh
@@ -67,5 +67,121 @@ if ! docker run --rm \
 fi
 echo "  read-only rootfs ok"
 
+# Test 7: push-templates.sh skips unchanged templates (diff logic)
+echo "Test 7: diff-based skip logic..."
+TEST7=$(mktemp)
+cat >"$TEST7" <<'TESTSCRIPT'
+#!/bin/bash
+set -euo pipefail
+export CODER_URL=http://fake CODER_SESSION_TOKEN=fake
+export TEMPLATES_DIR=$(mktemp -d)
+mkdir -p "${TEMPLATES_DIR}/mytemplate"
+echo "resource {}" > "${TEMPLATES_DIR}/mytemplate/main.tf"
+
+cat > /tmp/coder <<'MOCK'
+#!/bin/bash
+if [ "$1" = "templates" ] && [ "$2" = "pull" ]; then
+  cp -a "${TEMPLATES_DIR}/$3/." "$4/"
+  exit 0
+elif [ "$1" = "templates" ] && [ "$2" = "push" ]; then
+  echo "UNEXPECTED_PUSH" >&2
+  exit 1
+fi
+MOCK
+chmod +x /tmp/coder
+export PATH="/tmp:$PATH"
+
+output=$(/usr/local/bin/push-templates.sh 2>&1)
+if echo "$output" | grep -q "SKIP: mytemplate"; then
+  echo "  skip-unchanged ok"
+else
+  echo "  ERROR: expected SKIP for unchanged template"
+  echo "  output: $output"
+  exit 1
+fi
+TESTSCRIPT
+chmod 644 "$TEST7"
+docker run --rm --tmpfs /tmp:rw,exec,size=16m \
+  -v "$TEST7:/test-diff.sh:ro" \
+  --entrypoint bash "$IMAGE_REF" -c "bash /test-diff.sh"
+rm -f "$TEST7"
+
+# Test 8: push-templates.sh pushes changed templates
+echo "Test 8: diff-based push on change..."
+TEST8=$(mktemp)
+cat >"$TEST8" <<'TESTSCRIPT'
+#!/bin/bash
+set -euo pipefail
+export CODER_URL=http://fake CODER_SESSION_TOKEN=fake
+export TEMPLATES_DIR=$(mktemp -d)
+mkdir -p "${TEMPLATES_DIR}/mytemplate"
+echo "resource {}" > "${TEMPLATES_DIR}/mytemplate/main.tf"
+
+cat > /tmp/coder <<'MOCK'
+#!/bin/bash
+if [ "$1" = "templates" ] && [ "$2" = "pull" ]; then
+  echo "old content" > "$4/main.tf"
+  exit 0
+elif [ "$1" = "templates" ] && [ "$2" = "push" ]; then
+  echo "pushed"
+  exit 0
+fi
+MOCK
+chmod +x /tmp/coder
+export PATH="/tmp:$PATH"
+
+output=$(/usr/local/bin/push-templates.sh 2>&1)
+if echo "$output" | grep -q "CHANGED: mytemplate"; then
+  echo "  push-changed ok"
+else
+  echo "  ERROR: expected CHANGED for modified template"
+  echo "  output: $output"
+  exit 1
+fi
+TESTSCRIPT
+chmod 644 "$TEST8"
+docker run --rm --tmpfs /tmp:rw,exec,size=16m \
+  -v "$TEST8:/test-diff.sh:ro" \
+  --entrypoint bash "$IMAGE_REF" -c "bash /test-diff.sh"
+rm -f "$TEST8"
+
+# Test 9: push-templates.sh creates new templates (pull fails)
+echo "Test 9: new template creation..."
+TEST9=$(mktemp)
+cat >"$TEST9" <<'TESTSCRIPT'
+#!/bin/bash
+set -euo pipefail
+export CODER_URL=http://fake CODER_SESSION_TOKEN=fake
+export TEMPLATES_DIR=$(mktemp -d)
+mkdir -p "${TEMPLATES_DIR}/newtemplate"
+echo "resource {}" > "${TEMPLATES_DIR}/newtemplate/main.tf"
+
+cat > /tmp/coder <<'MOCK'
+#!/bin/bash
+if [ "$1" = "templates" ] && [ "$2" = "pull" ]; then
+  exit 1
+elif [ "$1" = "templates" ] && [ "$2" = "push" ]; then
+  echo "pushed"
+  exit 0
+fi
+MOCK
+chmod +x /tmp/coder
+export PATH="/tmp:$PATH"
+
+output=$(/usr/local/bin/push-templates.sh 2>&1)
+if echo "$output" | grep -q "NEW: newtemplate"; then
+  echo "  new-template ok"
+else
+  echo "  ERROR: expected NEW for non-existent template"
+  echo "  output: $output"
+  exit 1
+fi
+TESTSCRIPT
+chmod 644 "$TEST9"
+docker run --rm --tmpfs /tmp:rw,exec,size=16m \
+  -v "$TEST9:/test-diff.sh:ro" \
+  --entrypoint bash "$IMAGE_REF" -c "bash /test-diff.sh"
+rm -f "$TEST9"
+
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

- Pull active template version from Coder via `coder templates pull` before pushing; compare with `diff -rq` and skip when content is identical
- New templates (where pull fails) are always pushed as before
- Adds `skipped` counter to summary output alongside existing `pushed`/`failed`
- Three new tests covering skip-unchanged, push-changed, and new-template scenarios using mock `coder` binary

Closes #511

## Test plan

- [ ] CI builds image and runs `test.sh` (tests 7-9 validate diff logic)
- [ ] Verify skip-unchanged: mock pull returns identical files → "SKIP" in output
- [ ] Verify push-changed: mock pull returns different files → "CHANGED" + push runs
- [ ] Verify new-template: mock pull fails → "NEW" + push runs
- [ ] ShellCheck + shfmt pass (pre-commit validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)