### PR TITLE
feat(ssh-key-rotation)!: make script configurable via env vars

### DIFF
--- a/ssh-key-rotation/Dockerfile
+++ b/ssh-key-rotation/Dockerfile
@@ -1,9 +1,15 @@
-# SSH Key Rotation image for Coder workspace SSH signing/auth key rotation.
+# SSH Key Rotation — rotates SSH auth + signing keys for any GitHub user account.
 # Designed for PSA restricted: non-root (UID 1000), read-only root filesystem,
 # all caps dropped. Keypair material written to /tmp (mount as memory emptyDir).
 #
 # Required env:
-#   GITHUB_PAT - GitHub PAT with admin:public_key + admin:ssh_signing_key scopes
+#   GITHUB_PAT       — PAT with admin:public_key + admin:ssh_signing_key scopes
+#   TITLE_PREFIX     — GitHub key title prefix (e.g. "coder-workspace")
+#   SECRET_NAME      — Kubernetes secret to patch
+#   SECRET_NAMESPACE — Namespace of that secret
+# Optional env:
+#   FORCE_SYNC_NAMESPACES — comma-separated namespaces for ExternalSecret force-sync
+#   FORCE_SYNC_ES_NAME    — ExternalSecret name to sync
 #
 # Pin to specific digest for supply chain security (renovate updates this)
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11

--- a/ssh-key-rotation/assets/rotate-ssh-key.sh
+++ b/ssh-key-rotation/assets/rotate-ssh-key.sh
@@ -1,17 +1,38 @@
 #!/bin/sh
-# Rotate Coder workspace SSH auth + signing keys.
-# Ported verbatim from spruyt-labs cluster/apps/coder-system/coder/app/ssh-key-rotation/cronjob.yaml
-# (Kustomize $${VAR} escaping unwrapped to plain ${VAR}).
+# Rotate SSH auth + signing keys for a GitHub user account.
+#
+# Required env:
+#   GITHUB_PAT        — PAT with admin:public_key + admin:ssh_signing_key
+#   TITLE_PREFIX      — GitHub key title prefix (e.g. "coder-workspace")
+#   SECRET_NAME       — Kubernetes secret to patch
+#   SECRET_NAMESPACE  — Namespace of that secret
+#
+# Optional env:
+#   FORCE_SYNC_NAMESPACES — comma-separated namespaces for ExternalSecret force-sync
+#   FORCE_SYNC_ES_NAME    — ExternalSecret name to sync (required if FORCE_SYNC_NAMESPACES set)
 
 set -e
 
-TITLE_PREFIX="coder-workspace"
+fail() { echo "ERROR: $1" >&2; exit 1; }
+
+# --- Validate required env vars ---
+[ -z "${GITHUB_PAT}" ] && fail "GITHUB_PAT is required"
+[ -z "${TITLE_PREFIX}" ] && fail "TITLE_PREFIX is required"
+[ -z "${SECRET_NAME}" ] && fail "SECRET_NAME is required"
+[ -z "${SECRET_NAMESPACE}" ] && fail "SECRET_NAMESPACE is required"
+
+if [ -n "${FORCE_SYNC_NAMESPACES}" ] && [ -z "${FORCE_SYNC_ES_NAME}" ]; then
+  fail "FORCE_SYNC_ES_NAME is required when FORCE_SYNC_NAMESPACES is set"
+fi
+
 DATE_SUFFIX=$(date +%Y%m%d)
 TITLE="${TITLE_PREFIX}-${DATE_SUFFIX}"
 
 echo "=== SSH key rotation (auth + signing) ==="
+echo "Title prefix: ${TITLE_PREFIX}"
+echo "Secret: ${SECRET_NAME} in ${SECRET_NAMESPACE}"
 
-# Generate new SSH key pair
+# --- Generate new SSH key pair ---
 ssh-keygen -t ed25519 -f /tmp/id_ed25519 -N "" -C "${TITLE}"
 PUB_KEY=$(cat /tmp/id_ed25519.pub)
 echo "New key generated"
@@ -27,8 +48,7 @@ NEW_AUTH_ID=$(curl -s -X POST \
   jq -r '.id')
 
 if [ -z "${NEW_AUTH_ID}" ] || [ "${NEW_AUTH_ID}" = "null" ]; then
-  echo "ERROR: Failed to add authentication key to GitHub"
-  exit 1
+  fail "Failed to add authentication key to GitHub"
 fi
 echo "Authentication key added with ID: ${NEW_AUTH_ID}"
 
@@ -43,8 +63,7 @@ NEW_SIGN_ID=$(curl -s -X POST \
   jq -r '.id')
 
 if [ -z "${NEW_SIGN_ID}" ] || [ "${NEW_SIGN_ID}" = "null" ]; then
-  echo "ERROR: Failed to add signing key to GitHub"
-  exit 1
+  fail "Failed to add signing key to GitHub"
 fi
 echo "Signing key added with ID: ${NEW_SIGN_ID}"
 
@@ -86,11 +105,32 @@ curl -s \
 echo "Updating Kubernetes secret..."
 PRIV_KEY=$(base64 -w0 </tmp/id_ed25519)
 PUB_KEY_B64=$(printf '%s' "${PUB_KEY}" | base64 -w0)
-kubectl patch secret coder-ssh-signing-key -n coder-system \
+kubectl patch secret "${SECRET_NAME}" -n "${SECRET_NAMESPACE}" \
   --type='json' \
   -p="[{\"op\": \"replace\", \"path\": \"/data/id_ed25519\", \"value\": \"${PRIV_KEY}\"},{\"op\": \"replace\", \"path\": \"/data/id_ed25519.pub\", \"value\": \"${PUB_KEY_B64}\"}]"
 
-# Clean up
+# --- Force-sync ExternalSecrets (optional) ---
+if [ -n "${FORCE_SYNC_NAMESPACES}" ]; then
+  echo "=== Force-syncing ExternalSecrets ==="
+  IFS=',' ; set -- ${FORCE_SYNC_NAMESPACES} ; unset IFS
+  FAILURES=0
+  for NS in "$@"; do
+    echo "Force-syncing ${FORCE_SYNC_ES_NAME} in ${NS}..."
+    if ! kubectl patch externalsecret "${FORCE_SYNC_ES_NAME}" -n "${NS}" \
+      --type='merge' \
+      -p="{\"metadata\":{\"annotations\":{\"force-sync\":\"$(date +%s)\"}}}"; then
+      echo "WARNING: force-sync in ${NS} failed (non-fatal; ES refreshInterval will recover)"
+      FAILURES=$((FAILURES + 1))
+    fi
+  done
+  if [ ${FAILURES} -gt 0 ]; then
+    echo "=== Force-sync completed with ${FAILURES} non-fatal failure(s) ==="
+  else
+    echo "=== Force-sync complete ==="
+  fi
+fi
+
+# --- Clean up ---
 rm -f /tmp/id_ed25519 /tmp/id_ed25519.pub
 
 echo "=== SSH key rotation complete (auth + signing) ==="

--- a/ssh-key-rotation/assets/rotate-ssh-key.sh
+++ b/ssh-key-rotation/assets/rotate-ssh-key.sh
@@ -13,7 +13,10 @@
 
 set -e
 
-fail() { echo "ERROR: $1" >&2; exit 1; }
+fail() {
+  echo "ERROR: $1" >&2
+  exit 1
+}
 
 # --- Validate required env vars ---
 [ -z "${GITHUB_PAT}" ] && fail "GITHUB_PAT is required"
@@ -112,7 +115,10 @@ kubectl patch secret "${SECRET_NAME}" -n "${SECRET_NAMESPACE}" \
 # --- Force-sync ExternalSecrets (optional) ---
 if [ -n "${FORCE_SYNC_NAMESPACES}" ]; then
   echo "=== Force-syncing ExternalSecrets ==="
-  IFS=',' ; set -- ${FORCE_SYNC_NAMESPACES} ; unset IFS
+  IFS=','
+  # shellcheck disable=SC2086
+  set -- ${FORCE_SYNC_NAMESPACES}
+  unset IFS
   FAILURES=0
   for NS in "$@"; do
     echo "Force-syncing ${FORCE_SYNC_ES_NAME} in ${NS}..."

--- a/ssh-key-rotation/assets/rotate-ssh-key.sh
+++ b/ssh-key-rotation/assets/rotate-ssh-key.sh
@@ -13,6 +13,9 @@
 
 set -e
 
+cleanup() { rm -f /tmp/id_ed25519 /tmp/id_ed25519.pub; }
+trap cleanup EXIT
+
 fail() {
   echo "ERROR: $1" >&2
   exit 1
@@ -135,8 +138,5 @@ if [ -n "${FORCE_SYNC_NAMESPACES}" ]; then
     echo "=== Force-sync complete ==="
   fi
 fi
-
-# --- Clean up ---
-rm -f /tmp/id_ed25519 /tmp/id_ed25519.pub
 
 echo "=== SSH key rotation complete (auth + signing) ==="

--- a/ssh-key-rotation/metadata.yaml
+++ b/ssh-key-rotation/metadata.yaml
@@ -1,7 +1,7 @@
 ---
-# SSH Key Rotation - Coder workspace SSH key rotator
-# Custom image for spruyt-labs Coder ssh-key-rotation CronJob.
+# SSH Key Rotation - GitHub user SSH key rotator
+# Generic image for rotating SSH auth + signing keys on any GitHub user account.
 # Runs under PSA restricted (non-root, read-only root filesystem).
 
-version: "1.0"
+version: "2.0"
 auto_patch: true

--- a/ssh-key-rotation/test.sh
+++ b/ssh-key-rotation/test.sh
@@ -67,16 +67,14 @@ echo "  read-only rootfs ok"
 
 # Test 7: fails fast when required env vars are missing
 echo "Test 7: env var validation..."
-for VAR in GITHUB_PAT TITLE_PREFIX SECRET_NAME SECRET_NAMESPACE; do
-  OUTPUT=$(docker run --rm \
-    --read-only \
-    --tmpfs /tmp:rw,size=64m \
-    "$IMAGE_REF" 2>&1 || true)
-  if ! echo "$OUTPUT" | grep -q "ERROR:.*is required"; then
-    echo "  ERROR: script did not fail for missing env vars"
-    exit 1
-  fi
-done
+OUTPUT=$(docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,size=64m \
+  "$IMAGE_REF" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "ERROR:.*is required"; then
+  echo "  ERROR: script did not fail for missing env vars"
+  exit 1
+fi
 echo "  env var validation ok"
 
 # Test 8: fails when FORCE_SYNC_NAMESPACES set without FORCE_SYNC_ES_NAME

--- a/ssh-key-rotation/test.sh
+++ b/ssh-key-rotation/test.sh
@@ -65,5 +65,36 @@ if ! docker run --rm \
 fi
 echo "  read-only rootfs ok"
 
+# Test 7: fails fast when required env vars are missing
+echo "Test 7: env var validation..."
+for VAR in GITHUB_PAT TITLE_PREFIX SECRET_NAME SECRET_NAMESPACE; do
+  OUTPUT=$(docker run --rm \
+    --read-only \
+    --tmpfs /tmp:rw,size=64m \
+    "$IMAGE_REF" 2>&1 || true)
+  if ! echo "$OUTPUT" | grep -q "ERROR:.*is required"; then
+    echo "  ERROR: script did not fail for missing env vars"
+    exit 1
+  fi
+done
+echo "  env var validation ok"
+
+# Test 8: fails when FORCE_SYNC_NAMESPACES set without FORCE_SYNC_ES_NAME
+echo "Test 8: FORCE_SYNC_ES_NAME required with FORCE_SYNC_NAMESPACES..."
+OUTPUT=$(docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,size=64m \
+  -e GITHUB_PAT=fake \
+  -e TITLE_PREFIX=test \
+  -e SECRET_NAME=test \
+  -e SECRET_NAMESPACE=test \
+  -e FORCE_SYNC_NAMESPACES=ns1 \
+  "$IMAGE_REF" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "FORCE_SYNC_ES_NAME is required"; then
+  echo "  ERROR: script did not fail for missing FORCE_SYNC_ES_NAME"
+  exit 1
+fi
+echo "  conditional validation ok"
+
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary
- Replace hardcoded Coder-specific values with required env vars (TITLE_PREFIX, SECRET_NAME, SECRET_NAMESPACE)
- Add optional FORCE_SYNC_NAMESPACES + FORCE_SYNC_ES_NAME for ExternalSecret force-sync
- Script fails fast if required vars unset — no defaults
- Add test cases for env var validation

## Linked Issue
Closes #516

## Changes
- assets/rotate-ssh-key.sh — env var driven, validation block, optional ES force-sync
- Dockerfile — updated header docs
- metadata.yaml — bump to 2.0, updated description
- test.sh — tests 7+8 for env var validation

## Testing
- Existing tests 1-6 unchanged (binaries, UID, entrypoint, syntax, kubectl, read-only rootfs)
- Test 7: verifies script fails when required env vars missing
- Test 8: verifies FORCE_SYNC_ES_NAME required when FORCE_SYNC_NAMESPACES is provided

## Breaking Change
All callers must provide TITLE_PREFIX, SECRET_NAME, SECRET_NAMESPACE. Companion PR in spruyt-labs will update CronJobs.