### PR TITLE
chore: nuke github mcp in favor of cli

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,13 +6,6 @@
       "headers": {
         "X-API-KEY": "${BRAVE_SEARCH_MCP_API_KEY}"
       }
-    },
-    "github": {
-      "type": "http",
-      "url": "https://github-mcp.lan.${EXTERNAL_DOMAIN}/mcp",
-      "headers": {
-        "X-API-KEY": "${GITHUB_MCP_API_KEY}"
-      }
     }
   }
 }


### PR DESCRIPTION
nuke github mcp in favor of cli