### PR TITLE
chore(ci): clean up release descriptions

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -120,29 +120,17 @@ else
 fi
 
 cat <<EOF >/tmp/release-notes.md
-## Container Image
+\`${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}\`
+\`${DIGEST}\`
 
-**Image:** \`${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}\`
-**Digest:** \`${DIGEST}\`
-
-### Pull Commands
 \`\`\`bash
 docker pull ${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}
-docker pull ${REGISTRY}/${OWNER}/${IMAGE_NAME}@${DIGEST}
 \`\`\`
 
-### Build Info
-- **Upstream:** ${UPSTREAM_DISPLAY}
-- **Build Commit:** ${SHA}
-- **Workflow Run:** [#${RUN_NUMBER}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID})
+**Upstream:** ${UPSTREAM_DISPLAY} | **Commit:** ${SHA} | **Run:** [#${RUN_NUMBER}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID})
 
 ### Changes
 ${CHANGELOG}
-
-### Security
-- Trivy vulnerability scan: Passed (CRITICAL/HIGH)
-- SBOM: Included in image
-- Provenance: Attested
 EOF
 
 # --- Create or update release ---

--- a/.github/scripts/validate-configuration.sh
+++ b/.github/scripts/validate-configuration.sh
@@ -17,6 +17,7 @@ ERRORS=0
 # Source shared version handling functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/version-handling.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/version-handling.sh"
 
 # Determine effective upstream (input takes precedence)
@@ -66,8 +67,7 @@ fi
 
 # Test release notes generation (validates no injection issues)
 cat <<EOF >/tmp/release-notes-test.md
-## Container Image
-**Image:** \`ghcr.io/test/${IMAGE_NAME}:${TAG}\`
+\`ghcr.io/test/${IMAGE_NAME}:${TAG}\`
 **Upstream:** [${UPSTREAM}](https://github.com/${UPSTREAM})
 EOF
 if [ ! -s /tmp/release-notes-test.md ]; then


### PR DESCRIPTION
## Summary
- Remove static "Security" section (always identical, no signal)
- Remove duplicate digest-based pull command
- Collapse "Build Info" list into single inline metadata line
- Drop verbose section headings ("Container Image", "Pull Commands")
- Fix pre-existing SC1091 shellcheck warning in validate script

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)