### PR TITLE
fix(trivy): bump chrony, coder-gitops, devcontainer-common to remediate CVEs

### DIFF
--- a/chrony/metadata.yaml
+++ b/chrony/metadata.yaml
@@ -2,4 +2,4 @@
 # Chrony - Minimal NTP server with zero capabilities
 # Custom image for Kubernetes deployments requiring least privilege
 
-version: "4.8-r3"
+version: "4.8-r5"

--- a/coder-gitops/Dockerfile
+++ b/coder-gitops/Dockerfile
@@ -9,7 +9,7 @@ FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a50
 HEALTHCHECK NONE
 
 # renovate: datasource=github-releases depName=coder/coder
-ARG CODER_VERSION=v2.32.1
+ARG CODER_VERSION=v2.33.0
 
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 ARG KUBECTL_VERSION=v1.36.0

--- a/devcontainer-common/assets/.devcontainer.json
+++ b/devcontainer-common/assets/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1.1.0@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671": {
-      "version": "2.89.0"
+      "version": "2.92.0"
     },
     "ghcr.io/devcontainers/features/node:2.0.0@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f": {
       "version": "24.14.1"


### PR DESCRIPTION
## Summary

- **chrony** 4.8-r5: rebuild picks up gnutls 3.8.13-r0, fixing CVE-2026-33845 (critical) and CVE-2026-33846 (high)
- **coder-gitops**: Coder CLI v2.32.1 → v2.33.0 — bumps Go to 1.25.9 and otel to v1.43.0, resolving remaining medium CVE
- **devcontainer-common**: gh CLI 2.89.0 → 2.92.0 — built with Go 1.26.2, fixes CVE-2026-29181 (OTel, high) and multiple Go stdlib CVEs

### Not addressed (upstream blocked)

- **firemerge**: already on latest v0.5.6. Rebuild via `workflow_dispatch` would fix OS-level CVEs (libssl3t64, libc-bin). Python deps (pillow, cryptography, python-multipart) need upstream lockfile update.
- **megalinter flavors**: already on latest v9.4.0. CVEs in Alpine packages and Go binaries shipped by MegaLinter upstream.
- **claude-agent-read/spruyt-labs**: all critical/high unfixed in Debian Bookworm — no patches available.

## Test plan

- [ ] CI builds all 3 images successfully
- [ ] Trivy scans pass (or show reduced CVE counts)
- [ ] After merge, verify Trivy issues #542, #460, #478 show improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)