### PR TITLE
chore(renovate): add repo-specific overrides file

### DIFF
--- a/.github/renovate-overrides.json5
+++ b/.github/renovate-overrides.json5
@@ -1,0 +1,30 @@
+// Repo-specific Renovate overrides — not synced after creation
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Weekly batch for all non-major updates (excludes named groups)",
+      matchUpdateTypes: ["minor", "patch", "digest", "pin", "pinDigest"],
+      matchPackageNames: [
+        "!kubernetes",
+        "!kubernetes/kubernetes",
+        "!siderolabs/talos",
+        "!ghcr.io/siderolabs/installer",
+        "!ghcr.io/siderolabs/kubelet",
+        "!bitnami/kubectl",
+        "!public.ecr.aws/bitnami/kubectl",
+        "!alpine/k8s",
+        "!cilium",
+        "!cilium/cilium-cli",
+        "!cilium/hubble",
+        "!quay.io/cilium/cilium",
+        "!quay.io/cilium/operator-generic"
+      ],
+      schedule: ["before 9am on monday"],
+      groupName: "weekly-dependencies",
+      group: {
+        commitMessageTopic: "weekly dependency updates"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.github/renovate-overrides.json5` with the weekly dependency batch rule
- Moves this rule from shared repo-operator config to a local overrides file for correct last-match-wins semantics

## Linked Issue
Closes #577

## Changes
- Created `.github/renovate-overrides.json5` containing the weekly batch `packageRule` for non-major updates, excluding named groups (Kubernetes, Talos, Cilium)

## Testing
- Renovate dry-run will validate the JSON5 syntax on next scheduled run
- Rule semantics are identical to the previous shared config entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)