### PR TITLE
chore(claude-agent-spruyt-labs): remove hubble CLI

### DIFF
--- a/claude-agent-spruyt-labs/Dockerfile
+++ b/claude-agent-spruyt-labs/Dockerfile
@@ -65,13 +65,6 @@ RUN ARCH="$(dpkg --print-architecture)" \
   && curl -fsSL --retry 3 --retry-delay 5 "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_VERSION}/cilium-linux-${ARCH}.tar.gz" \
   | tar -xz -C /usr/local/bin
 
-# hubble
-# renovate: depName=cilium/hubble datasource=github-releases
-ARG HUBBLE_VERSION="v1.19.3"
-RUN ARCH="$(dpkg --print-architecture)" \
-  && curl -fsSL --retry 3 --retry-delay 5 "https://github.com/cilium/hubble/releases/download/${HUBBLE_VERSION}/hubble-linux-${ARCH}.tar.gz" \
-  | tar -xz -C /usr/local/bin
-
 # talosctl
 # renovate: depName=siderolabs/talos datasource=github-releases
 ARG TALOSCTL_VERSION="v1.13.0"

--- a/claude-agent-spruyt-labs/test.sh
+++ b/claude-agent-spruyt-labs/test.sh
@@ -9,7 +9,7 @@ docker run --rm "$IMAGE" bash -c '
 set -euo pipefail
 
 for bin in claude node python3 git npm jq gh rg \
-           kubectl kustomize helm helmfile cilium hubble \
+           kubectl kustomize helm helmfile cilium \
            talosctl flux velero kubectl-cnpg falcoctl; do
   if ! command -v "$bin" &>/dev/null; then
     echo "FAIL: $bin not found"


### PR DESCRIPTION
## Summary
- Remove hubble CLI from claude-agent-spruyt-labs image (no longer needed)

Closes #576

## Test plan
- [ ] CI builds image successfully without hubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)