### PR TITLE
chore(lint): pin megalinter image and add renovate tracking

### DIFF
--- a/lint-config.sh
+++ b/lint-config.sh
@@ -4,8 +4,8 @@
 # This file is sourced by lint.sh for both local and CI runs
 
 # MegaLinter Docker image (use digest for reproducibility)
-# renovate: TODO
-MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images:latest"
+# renovate: datasource=docker depName=ghcr.io/anthony-spruyt/megalinter-container-images
+MEGALINTER_IMAGE="ghcr.io/anthony-spruyt/megalinter-container-images:v10.0.34@sha256:c5b536dac1b500804e42beb3069019e6c823b0ee140952179d473fbae37e7005"
 
 # Skip linting for renovate/dependabot commits in CI
 SKIP_BOT_COMMITS=true


### PR DESCRIPTION
## Summary
- Pin `megalinter-container-images` to `v10.0.34` with digest instead of `:latest`
- Replace TODO renovate annotation with `datasource=docker` for automatic version updates

## Test plan
- [ ] Verify `./lint.sh` runs successfully with pinned image
- [ ] Confirm Renovate picks up the annotation and creates update PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)