### PR TITLE
fix(megalinter): add missing auto_patch to firemerge and sungather

### DIFF
--- a/megalinter-firemerge/metadata.yaml
+++ b/megalinter-firemerge/metadata.yaml
@@ -1,1 +1,2 @@
 version: "1.0.0"
+auto_patch: true

--- a/megalinter-sungather/metadata.yaml
+++ b/megalinter-sungather/metadata.yaml
@@ -1,1 +1,2 @@
 version: "1.0.0"
+auto_patch: true


### PR DESCRIPTION
## Summary
- Add `auto_patch: true` to `megalinter-firemerge/metadata.yaml`
- Add `auto_patch: true` to `megalinter-sungather/metadata.yaml`
- Without this, CI does not auto-increment patch versions on rebuild

## Test plan
- [ ] Verify CI builds both flavors with auto-incremented patch versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)