### PR TITLE
fix(megalinter): use base version without patch for auto_patch

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -222,7 +222,7 @@ jobs:
           fi
 
   build:
-    name: Build and Test
+    name: Build, Test and Publish
     needs: check-release
     if: needs.check-release.outputs.should-build == 'true'
     runs-on: ubuntu-latest

--- a/megalinter-firemerge/metadata.yaml
+++ b/megalinter-firemerge/metadata.yaml
@@ -1,2 +1,2 @@
-version: "1.0.0"
+version: "1.0"
 auto_patch: true

--- a/megalinter-sungather/metadata.yaml
+++ b/megalinter-sungather/metadata.yaml
@@ -1,2 +1,2 @@
-version: "1.0.0"
+version: "1.0"
 auto_patch: true


### PR DESCRIPTION
## Summary
- Fix `megalinter-firemerge` and `megalinter-sungather` version from `"1.0.0"` to `"1.0"`
- With `auto_patch: true`, CI appends `.N` — so `"1.0.0"` produces `1.0.0.0` instead of `1.0.0`

## Test plan
- [ ] Verify CI builds produce correct version format (e.g., `1.0.0`, `1.0.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)