### PR TITLE
fix(megalinter-spruyt-labs): pre-copy Biome descriptor at build time

### DIFF
--- a/megalinter-spruyt-labs/flavor.yaml
+++ b/megalinter-spruyt-labs/flavor.yaml
@@ -33,14 +33,9 @@ biome_version: "2.4.14"
 extra_dockerfile: |
   ARG BIOME_VERSION={{ flavor.biome_version }}
   RUN npm install -g @biomejs/biome@${BIOME_VERSION} && npm cache clean --force && rm -rf /root/.npm/_cacache
-  COPY mega-linter-plugin-biome /mega-linter-plugin-biome
-  # Note: runtime -e PLUGINS=... overrides this default; include baked-in paths alongside additions
-  ENV PLUGINS='["file:///mega-linter-plugin-biome/biome.megalinter-descriptor.yml"]'
+  COPY mega-linter-plugin-biome/biome.megalinter-descriptor.yml /megalinter-descriptors/biome.megalinter-descriptor.yml
 
 extra_test_linters:
   - name: biome
     version_command: "biome --version"
 
-extra_test_env_vars:
-  - name: PLUGINS
-    contains: "biome.megalinter-descriptor.yml"

--- a/megalinter-spruyt-labs/flavor.yaml
+++ b/megalinter-spruyt-labs/flavor.yaml
@@ -38,4 +38,3 @@ extra_dockerfile: |
 extra_test_linters:
   - name: biome
     version_command: "biome --version"
-

--- a/megalinter-spruyt-labs/mega-linter-plugin-biome/biome.megalinter-descriptor.yml
+++ b/megalinter-spruyt-labs/mega-linter-plugin-biome/biome.megalinter-descriptor.yml
@@ -2,6 +2,7 @@
 # descriptor_id: TYPESCRIPT merges with any upstream TYPESCRIPT descriptor per MegaLinter plugin semantics
 descriptor_id: TYPESCRIPT
 descriptor_type: language
+is_plugin: true
 # JSON/JSONC omitted — MegaLinter has dedicated JSON linters (JSON_JSONLINT)
 # CSS included here because Biome lints CSS but MegaLinter has no CSS descriptor to merge with
 file_extensions:


### PR DESCRIPTION
## Summary

- Pre-copy Biome plugin descriptor into `/megalinter-descriptors/` at build time instead of relying on runtime `PLUGINS` env var
- Add `is_plugin: true` to descriptor so MegaLinter's linter_factory includes it regardless of flavor linter list

## Linked Issue

Closes #605

## Changes

- `flavor.yaml`: Replace `ENV PLUGINS` + `COPY` plugin dir with direct `COPY` of descriptor into `/megalinter-descriptors/`
- `biome.megalinter-descriptor.yml`: Add `is_plugin: true` field
- Remove `extra_test_env_vars` for PLUGINS (no longer needed)

## Root Cause

`plugin_factory.load_plugin` copies the descriptor into `/megalinter-descriptors/` at runtime. That directory is `root:root` with `drwxr-xr-x` — non-root users can't write to it. `lint.sh` runs containers with `-u $(id -u):$(id -g)`, causing `PermissionError`.

## Testing

- Verified `is_plugin` flag is required by `linter_factory.py:28` (linters without it or without flavor membership are filtered out)
- Regenerated Dockerfile/test.sh via `generate.py` — output correct
