### PR TITLE
ci(pipeline): add timeout-minutes to all jobs

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -56,6 +56,7 @@ concurrency:
 jobs:
   check-release:
     name: Check Release
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
       contents: read # Read releases
@@ -223,6 +224,7 @@ jobs:
 
   build:
     name: Build, Test and Publish
+    timeout-minutes: 30
     needs: check-release
     if: needs.check-release.outputs.should-build == 'true'
     runs-on: ubuntu-latest
@@ -446,6 +448,7 @@ jobs:
 
   create-release:
     name: Create Missing Release
+    timeout-minutes: 5
     needs: check-release
     if: >-
       inputs.push &&


### PR DESCRIPTION
## Summary

- Add `timeout-minutes` to all three jobs in `_image-pipeline.yaml` to prevent runaway builds from consuming runner time
- Values based on historic job runtimes with comfortable headroom:
  - `check-release`: 5 min (observed: ~10s)
  - `build`: 30 min (observed: up to ~7 min)
  - `create-release`: 5 min (observed: <1 min)

Closes #607

## Test plan

- [ ] Verify CI passes (yaml lint, actionlint)
- [ ] Confirm timeouts appear in workflow visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)