### PR TITLE
chore(renovate): remove weekly-dependencies mega-group

### DIFF
--- a/.github/renovate-overrides.json5
+++ b/.github/renovate-overrides.json5
@@ -1,36 +1,15 @@
+// Repo-specific Renovate overrides
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "description": "Weekly batch for all non-major updates (excludes named groups)",
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest",
-        "pin",
-        "pinDigest"
-      ],
-      "matchPackageNames": [
-        "!kubernetes",
-        "!kubernetes/kubernetes",
-        "!siderolabs/talos",
-        "!ghcr.io/siderolabs/installer",
-        "!ghcr.io/siderolabs/kubelet",
-        "!bitnami/kubectl",
-        "!public.ecr.aws/bitnami/kubectl",
-        "!alpine/k8s",
-        "!cilium",
-        "!cilium/cilium-cli",
-        "!cilium/hubble",
-        "!quay.io/cilium/cilium",
-        "!quay.io/cilium/operator-generic"
-      ],
-      "schedule": [
-        "before 9am on monday"
-      ],
-      "groupName": "weekly-dependencies",
+      "description": "Batch renovate CLI updates weekly (releases multiple times daily)",
+      "matchPackageNames": ["renovate"],
+      "matchDatasources": ["npm", "docker"],
+      "schedule": ["before 9am on monday"],
+      "groupName": "renovate-cli",
       "group": {
-        "commitMessageTopic": "weekly dependency updates"
+        "commitMessageTopic": "Renovate CLI"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Remove the `weekly-dependencies` group from `renovate-overrides.json5`
- Agents now review and merge Renovate PRs individually — batching unrelated deps into one weekly PR is riskier and harder for agents to handle than one-dep-at-a-time updates

## Test plan
- [ ] Verify Renovate dashboard no longer shows a "weekly-dependencies" group
- [ ] Confirm individual dependency PRs are created on next Renovate run

🤖 Generated with [Claude Code](https://claude.com/claude-code)