### PR TITLE
fix(ci): scope pipeline concurrency to ref to prevent cross-PR cancellation

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -46,11 +46,11 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
 
-# Prevent race condition: only one build per image at a time
-# With cancel-in-progress: false, the next queued build waits for the current one
-# When it starts, check-release will see any releases created by the previous build
+# Serialise releases: on main, only one build per image runs at a time so
+# check-release sees any releases created by the previous build.
+# Including github.ref keeps PR builds independent of each other and of main.
 concurrency:
-  group: release-${{ inputs.image }}
+  group: release-${{ inputs.image }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- The `_image-pipeline.yaml` concurrency group `release-<image>` was shared across all branches/PRs
- When multiple Renovate PRs triggered builds for the same image simultaneously, GitHub Actions cancelled queued runs (keeps max 1 running + 1 pending per group)
- Scoped the group to `release-<image>-<ref>` so each PR gets its own concurrency lane while main branch pushes remain serialised per-image

## Evidence
Cancelled runs on 2026-05-12:
- `renovate/anthropic-ai-claude-code-2.1.128` → `claude-agent-spruyt-labs` Check Release cancelled
- `renovate/falcosecurity-falcoctl-v0.13.0` → `claude-agent-spruyt-labs` Check Release cancelled

Both competed for concurrency group `release-claude-agent-spruyt-labs`.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Open two PRs that modify the same image simultaneously — both should build without cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)