### PR TITLE
feat(ci): use shared trivy-scan composite action with SARIF upload

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -233,6 +233,7 @@ jobs:
       packages: write # Push to GHCR (gated by push input)
       id-token: write # OIDC for attestations
       attestations: write # Build provenance (gated by push input)
+      security-events: write # SARIF upload to GitHub code scanning
     outputs:
       digest: ${{ steps.push.outputs.digest }}
       tag: ${{ needs.check-release.outputs.tag }}
@@ -364,15 +365,13 @@ jobs:
           fi
 
       - name: Scan for vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: anthony-spruyt/repo-operator/.github/actions/trivy-scan@main
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ inputs.image }}:${{ needs.check-release.outputs.tag }}
-          scanners: ${{ steps.trivyconfig.outputs.scanners }}
-          format: table
-          exit-code: ${{ steps.trivyconfig.outputs.exitcode }}
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
           trivyignores: ${{ steps.trivyconfig.outputs.ignorefile }}
+          scanners: ${{ steps.trivyconfig.outputs.scanners }}
+          exit-code: ${{ steps.trivyconfig.outputs.exitcode }}
+          category: trivy-${{ inputs.image }}
 
       - name: Dry run summary
         if: ${{ !inputs.push }}


### PR DESCRIPTION
## Summary
- Replace inline `aquasecurity/trivy-action` in `_image-pipeline.yaml` with the shared `anthony-spruyt/repo-operator/.github/actions/trivy-scan@main` composite action
- Adds SARIF upload to GitHub code scanning for every image build
- Each image scan uses a unique category (`trivy-<image-name>`) to support multiple images in the same workflow run

## Changes
- **`_image-pipeline.yaml`**: Replaced inline Trivy step with composite action, added `security-events: write` permission to `build` job
- Per-image trivyignore detection logic preserved (the `Determine trivy config` step is unchanged)
- Per-image `scanners` and `exit-code` overrides for dev/megalinter images preserved
- `severity`, `ignore-unfixed`, and `format` removed from the call since the composite action defaults match the previous values (`CRITICAL,HIGH`, `true`, table+SARIF)

## Linked Issue
Ref anthony-spruyt/spruyt-labs#1384

## Testing
- The composite action is already tested and confirmed working in spruyt-labs (PR #1387 verified SARIF uploads)
- This PR can be verified by triggering a manual workflow_dispatch build for any image and checking:
  - [ ] Table scan output appears in the build log
  - [ ] SARIF results appear in the repository's Security > Code scanning tab
  - [ ] Per-image trivyignore files are still respected
  - [ ] Dev/megalinter images still use warn-only mode (exit-code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)