### PR TITLE
fix(claude-agent-spruyt-labs): add Go and pre-commit

### DIFF
--- a/claude-agent-spruyt-labs/Dockerfile
+++ b/claude-agent-spruyt-labs/Dockerfile
@@ -104,6 +104,13 @@ RUN ARCH="$(dpkg --print-architecture)" \
   && curl -fsSL --retry 3 --retry-delay 5 "https://github.com/falcosecurity/falcoctl/releases/download/${FALCOCTL_VERSION}/falcoctl_${FALCOCTL_VERSION_NUM}_linux_${ARCH}.tar.gz" \
   | tar -xz -C /usr/local/bin falcoctl
 
+# Go
+# renovate: depName=golang datasource=docker
+ARG GO_VERSION="1.26.2"
+RUN ARCH="$(dpkg --print-architecture)" \
+  && curl -fsSL --retry 3 --retry-delay 5 "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 # Aikido safe-chain (installed globally, then set up for node user)
 # renovate: depName=@aikidosec/safe-chain datasource=npm
 ARG SAFE_CHAIN_VERSION="1.5.2"
@@ -113,6 +120,11 @@ RUN npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION}"
 USER 1000
 RUN safe-chain setup && safe-chain setup-ci
 ENV PATH="/home/node/.safe-chain/shims:${PATH}"
+
+# pre-commit
+# renovate: depName=pre-commit datasource=pypi
+ARG PRECOMMIT_VERSION="4.6.0"
+RUN pip install --no-cache-dir --break-system-packages pre-commit=="${PRECOMMIT_VERSION}"
 
 # Claude Code CLI (native binary — npm datasource tracks versions)
 # renovate: depName=@anthropic-ai/claude-code datasource=npm

--- a/claude-agent-spruyt-labs/test.sh
+++ b/claude-agent-spruyt-labs/test.sh
@@ -8,7 +8,7 @@ echo "Testing claude-agent-spruyt-labs image..."
 docker run --rm "$IMAGE" bash -c '
 set -euo pipefail
 
-for bin in claude node python3 git npm jq gh rg \
+for bin in claude node python3 git npm jq gh rg go pre-commit \
            kubectl kustomize helm helmfile cilium \
            talosctl flux velero kubectl-cnpg falcoctl; do
   if ! command -v "$bin" &>/dev/null; then
@@ -22,6 +22,8 @@ claude --version
 safe-chain --version
 gh --version
 rg --version
+go version
+pre-commit --version
 kubectl version --client
 helm version
 flux --version


### PR DESCRIPTION
## Summary
- Add Go runtime (1.26.2) for building Go services
- Add pre-commit (4.6.0) for write-namespace init container compatibility
- Update test.sh to verify both new binaries

## Linked Issue
The spruyt-labs image serves both read and write roles but was missing Go and pre-commit, which the write image has. The Kyverno `inject-repo-clone-write` init container runs `pre-commit install` after cloning, causing exit 127 in write namespace pods.

## Changes
- `claude-agent-spruyt-labs/Dockerfile`: Add Go (system-level, before USER switch) and pre-commit (pip, as node user)
- `claude-agent-spruyt-labs/test.sh`: Add `go` and `pre-commit` to binary checks and version output

## Testing
- CI will build the image and run test.sh
- Verify `pre-commit install` succeeds in write-namespace init container after image deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)