### PR TITLE
chore(config): add agentmemory MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,15 @@
 {
   "mcpServers": {
+    "agentmemory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@agentmemory/mcp"],
+      "env": {
+        "AGENTMEMORY_URL": "${AGENTMEMORY_URL}",
+        "AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET}",
+        "SAFE_CHAIN_LOGGING": "silent"
+      }
+    },
     "bravesearch": {
       "type": "http",
       "url": "https://brave-search-mcp.lan.${EXTERNAL_DOMAIN}/mcp",


### PR DESCRIPTION
## Summary
- Add agentmemory MCP server configuration to `.mcp.json`
- Uses `@agentmemory/mcp` via npx with env vars for URL, secret, and logging

## Test plan
- [ ] Verify MCP server connects with valid `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)