### PR TITLE
fix(release): use unique heredoc delimiter to prevent commit message collision

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -119,7 +119,7 @@ else
   CHANGELOG=$(generate_local_changelog "$IMAGE_NAME" "$PREV_RELEASE")
 fi
 
-cat <<EOF >/tmp/release-notes.md
+cat <<__RELEASE_NOTES_DELIM__ >/tmp/release-notes.md
 \`${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}\`
 \`${DIGEST}\`
 
@@ -131,7 +131,7 @@ docker pull ${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}
 
 ### Changes
 ${CHANGELOG}
-EOF
+__RELEASE_NOTES_DELIM__
 
 # --- Create or update release ---
 


### PR DESCRIPTION
## Summary
- Replace `EOF` heredoc delimiter in `create-release.sh` with `__RELEASE_NOTES_DELIM__` to prevent commit messages containing "EOF" from truncating release notes

## Linked Issue
N/A — discovered during spruyt-labs release workflow audit

## Changes
- `EOF` → `__RELEASE_NOTES_DELIM__` in release notes heredoc (create-release.sh)

## Testing
Delimiter is only used for file redirection, no functional change unless a commit message contained "EOF" on its own line