### PR TITLE
feat(devcontainer): bootstrap Claude Code plugins from project settings

### DIFF
--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -50,6 +50,34 @@ export PATH="$HOME/.local/bin:$PATH"
 # shellcheck disable=SC2016
 grep -q 'local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$HOME/.bashrc"
 
+# Bootstrap Claude Code plugins from project settings
+if command -v claude &>/dev/null && command -v jq &>/dev/null; then
+  bootstrap_claude_plugins() {
+    local settings_file="$1"
+    [ -f "$settings_file" ] || return 0
+    jq empty "$settings_file" 2>/dev/null || { echo "  WARNING: invalid JSON in $settings_file, skipping"; return 0; }
+    echo "  reading $settings_file"
+    jq -r '.extraKnownMarketplaces // {} | to_entries[] | select(.value.source != null and .value.source.repo != null) | "\(.key)\t\(.value.source.repo)"' \
+      "$settings_file" 2>/dev/null | while IFS="$(printf '\t')" read -r name repo; do
+      echo "    marketplace: $name ($repo)"
+      claude plugins marketplace add "$repo" --scope user \
+        || echo "    WARNING: failed to add marketplace '$name'"
+    done
+    jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true or .value == "true") | .key' \
+      "$settings_file" 2>/dev/null | while IFS= read -r plugin; do
+      echo "    install: $plugin"
+      claude plugins install "$plugin" --scope user \
+        || echo "    WARNING: failed to install '$plugin'"
+    done
+  }
+  echo "Bootstrapping Claude Code plugins..."
+  # Settings precedence: user → project → local
+  bootstrap_claude_plugins "$HOME/.claude/settings.json"
+  # $WORKSPACE is set at top of script (points to repo clone root)
+  bootstrap_claude_plugins "$WORKSPACE/.claude/settings.json"
+  bootstrap_claude_plugins "$WORKSPACE/.claude/settings.local.json"
+fi
+
 # Podman userns config
 mkdir -p "$HOME/.config/containers/containers.conf.d"
 cat >"$HOME/.config/containers/containers.conf.d/10-userns.conf" <<'CONTAINERS_CONF'


### PR DESCRIPTION
## Summary
- Adds `bootstrap_claude_plugins()` function to `devcontainer-common/assets/post-create.sh`
- Reads `.claude/settings.json` and `.claude/settings.local.json` from cloned workspace
- Dynamically installs declared marketplaces and enabled plugins via `claude plugins` CLI
- Uses `--scope user` to write to `~/.claude/` (avoids dirtying git state)

## Linked Issue
Ref anthony-spruyt/spruyt-labs#1528

## Changes
- Add `bootstrap_claude_plugins()` function after Claude CLI installation
- Guard with `command -v claude && command -v jq` availability check
- Read user settings (`$HOME/.claude/settings.json`), project settings, and local settings
- Tab-delimited marketplace extraction with null-safe jq filters
- Accept both boolean `true` and string `"true"` for enabledPlugins
- Non-fatal JSON validation (warns and skips, doesn't block devcontainer startup)

## Testing
- Function tested in devcontainer environment with real `claude plugins` CLI commands
- Edge cases: missing file (skipped), empty JSON (no-op), disabled plugins (filtered), invalid JSON (warns, continues)
- All commands idempotent and fault-tolerant (logs warning on failure, continues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)