### PR TITLE
fix: remove cross-repo allowlists from .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,21 +6,6 @@
 # https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 useDefault = true
 
-# --- Global Allowlists ---
-# Repo-specific paths consolidated here for central management.
-[allowlist]
-paths = [
-  # spruyt-labs: ExternalSecret CRDs contain key references, not secret values
-  '''external-secret\.yaml$''',
-  # xfg: Test fixture files with non-sensitive test RSA keys
-  '''test/fixtures/test-fixtures\.ts$''',
-  '''fixtures/test-fixtures\.ts$''',
-  # Hookify rules contain example IPs in documentation
-  '''\.claude/hookify\..*\.local\.md$''',
-  # Hookify test cases contain example IPs for testing
-  '''tests/hooks/hookify_test_cases\.yaml$''',
-]
-
 # --- IP/CIDR Leakage Prevention ---
 # Prevents private IP addresses from being committed to public repositories.
 
@@ -30,34 +15,14 @@ description = "RFC1918 private IP address (10.x.x.x)"
 regex = '''(?:^|[^0-9])10\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
 tags = ["ip-leakage"]
 
-  [rules.allowlist]
-  paths = [
-    '''talos/''',
-    '''\.sops\.yaml$''',
-  ]
-
 [[rules]]
 id = "private-ip-rfc1918-172"
 description = "RFC1918 private IP address (172.16-31.x.x)"
 regex = '''(?:^|[^0-9])172\.(?:1[6-9]|2[0-9]|3[01])\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
 tags = ["ip-leakage"]
 
-  [rules.allowlist]
-  paths = [
-    '''talos/''',
-    '''\.sops\.yaml$''',
-  ]
-
 [[rules]]
 id = "private-ip-rfc1918-192"
 description = "RFC1918 private IP address (192.168.x.x)"
 regex = '''(?:^|[^0-9])192\.168\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(?:/[0-9]{1,2})?(?:[^0-9]|$)'''
 tags = ["ip-leakage"]
-
-  [rules.allowlist]
-  paths = [
-    '''talos/''',
-    '''\.sops\.yaml$''',
-    # SunGather example inverter addresses
-    '''sungather/''',
-  ]


### PR DESCRIPTION
## Summary

- Removed entire global `[allowlist]` section (5 paths for spruyt-labs, xfg, hookify — none relevant here)
- Removed `[rules.allowlist]` blocks from all 3 RFC1918 IP rules (`talos/`, `.sops.yaml$`, `sungather/` — all cross-repo)
- Verified `sungather/` not needed: only `megalinter-sungather/` exists (MegaLinter flavor, no example IPs)

Closes #695

## Test plan

- [ ] MegaLinter CI passes (gitleaks validates config on run)
- [ ] No false positives triggered on existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)