### PR TITLE
feat(devcontainer): add NEXUS_DOCKER_URL podman mirror support

### DIFF
--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -173,27 +173,46 @@ REGISTRIES_CONF
 # Local devcontainers inject this via containerEnv; Coder workspaces skip
 # this block and rely on the cluster ConfigMap mount instead.
 if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
-  cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
+  if ! echo "${NEXUS_DOCKER_URL}" | grep -qE '^(https?://)?[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
+    echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' does not match expected format (scheme://host[:port] or host[:port]), skipping mirror config"
+  else
+    cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
 [[registry]]
 prefix = "docker.io"
+location = "docker.io"
+
+[[registry.mirror]]
 location = "${NEXUS_DOCKER_URL}"
 
 [[registry]]
 prefix = "ghcr.io"
+location = "ghcr.io"
+
+[[registry.mirror]]
 location = "${NEXUS_DOCKER_URL}"
 
 [[registry]]
 prefix = "quay.io"
+location = "quay.io"
+
+[[registry.mirror]]
 location = "${NEXUS_DOCKER_URL}"
 
 [[registry]]
 prefix = "mcr.microsoft.com"
+location = "mcr.microsoft.com"
+
+[[registry.mirror]]
 location = "${NEXUS_DOCKER_URL}"
 
 [[registry]]
 prefix = "registry.k8s.io"
+location = "registry.k8s.io"
+
+[[registry.mirror]]
 location = "${NEXUS_DOCKER_URL}"
 MIRROR_CONF
+  fi
 fi
 
 echo ""

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -176,7 +176,7 @@ if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
   _nexus_mirror="${NEXUS_DOCKER_URL#http://}"
   _nexus_mirror="${_nexus_mirror#https://}"
   if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]+([._-][a-zA-Z0-9]+)*(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
-    echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' (scheme stripped: '${_nexus_mirror}') does not match expected format host[:port][/path], skipping mirror config"
+    echo "WARNING: NEXUS_DOCKER_URL does not match expected format host[:port][/path] (value redacted), skipping mirror config"
   else
     cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
 [[registry]]

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -175,8 +175,8 @@ REGISTRIES_CONF
 if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
   _nexus_mirror="${NEXUS_DOCKER_URL#http://}"
   _nexus_mirror="${_nexus_mirror#https://}"
-  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
-    echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' does not match expected format (scheme://host[:port] or host[:port]), skipping mirror config"
+  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9]*([._-][a-zA-Z0-9]+)*[a-zA-Z0-9])?(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
+    echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' (scheme stripped: '${_nexus_mirror}') does not match expected format host[:port][/path], skipping mirror config"
   else
     cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
 [[registry]]

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -175,7 +175,7 @@ REGISTRIES_CONF
 if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
   _nexus_mirror="${NEXUS_DOCKER_URL#http://}"
   _nexus_mirror="${_nexus_mirror#https://}"
-  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9]*([._-][a-zA-Z0-9]+)*[a-zA-Z0-9])?(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
+  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]+([._-][a-zA-Z0-9]+)*(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
     echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' (scheme stripped: '${_nexus_mirror}') does not match expected format host[:port][/path], skipping mirror config"
   else
     cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -169,6 +169,33 @@ location = "registry.k8s.io"
 location = "mcr.microsoft.com"
 REGISTRIES_CONF
 
+# Write Nexus pull-through mirror for podman if NEXUS_DOCKER_URL is set.
+# Local devcontainers inject this via containerEnv; Coder workspaces skip
+# this block and rely on the cluster ConfigMap mount instead.
+if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
+  cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
+[[registry]]
+prefix = "docker.io"
+location = "${NEXUS_DOCKER_URL}"
+
+[[registry]]
+prefix = "ghcr.io"
+location = "${NEXUS_DOCKER_URL}"
+
+[[registry]]
+prefix = "quay.io"
+location = "${NEXUS_DOCKER_URL}"
+
+[[registry]]
+prefix = "mcr.microsoft.com"
+location = "${NEXUS_DOCKER_URL}"
+
+[[registry]]
+prefix = "registry.k8s.io"
+location = "${NEXUS_DOCKER_URL}"
+MIRROR_CONF
+fi
+
 echo ""
 echo "Setting up devcontainer (repo-specific tooling)..."
 if [[ -x "$DEVCONTAINER_DIR/setup-devcontainer.sh" ]]; then

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -173,7 +173,9 @@ REGISTRIES_CONF
 # Local devcontainers inject this via containerEnv; Coder workspaces skip
 # this block and rely on the cluster ConfigMap mount instead.
 if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
-  if ! echo "${NEXUS_DOCKER_URL}" | grep -qE '^(https?://)?[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
+  _nexus_mirror="${NEXUS_DOCKER_URL#http://}"
+  _nexus_mirror="${_nexus_mirror#https://}"
+  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
     echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' does not match expected format (scheme://host[:port] or host[:port]), skipping mirror config"
   else
     cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF
@@ -182,35 +184,35 @@ prefix = "docker.io"
 location = "docker.io"
 
 [[registry.mirror]]
-location = "${NEXUS_DOCKER_URL}"
+location = "${_nexus_mirror}"
 
 [[registry]]
 prefix = "ghcr.io"
 location = "ghcr.io"
 
 [[registry.mirror]]
-location = "${NEXUS_DOCKER_URL}"
+location = "${_nexus_mirror}"
 
 [[registry]]
 prefix = "quay.io"
 location = "quay.io"
 
 [[registry.mirror]]
-location = "${NEXUS_DOCKER_URL}"
+location = "${_nexus_mirror}"
 
 [[registry]]
 prefix = "mcr.microsoft.com"
 location = "mcr.microsoft.com"
 
 [[registry.mirror]]
-location = "${NEXUS_DOCKER_URL}"
+location = "${_nexus_mirror}"
 
 [[registry]]
 prefix = "registry.k8s.io"
 location = "registry.k8s.io"
 
 [[registry.mirror]]
-location = "${NEXUS_DOCKER_URL}"
+location = "${_nexus_mirror}"
 MIRROR_CONF
   fi
 fi

--- a/devcontainer-common/assets/post-create.sh
+++ b/devcontainer-common/assets/post-create.sh
@@ -175,7 +175,7 @@ REGISTRIES_CONF
 if [ -n "${NEXUS_DOCKER_URL:-}" ]; then
   _nexus_mirror="${NEXUS_DOCKER_URL#http://}"
   _nexus_mirror="${_nexus_mirror#https://}"
-  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
+  if ! echo "${_nexus_mirror}" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?(:[0-9]+)?(/[a-zA-Z0-9._/-]*)?$'; then
     echo "WARNING: NEXUS_DOCKER_URL='${NEXUS_DOCKER_URL}' does not match expected format (scheme://host[:port] or host[:port]), skipping mirror config"
   else
     cat >"$HOME/.config/containers/registries.conf.d/99-nexus-mirror.conf" <<MIRROR_CONF


### PR DESCRIPTION
## Summary
- Add conditional podman registry mirror block to `post-create.sh`
- Mirror written to user-level `registries.conf.d/99-nexus-mirror.conf` when `NEXUS_DOCKER_URL` is set
- No-op when unset (Coder workspaces)

## Linked Issue
N/A

## Changes
- `devcontainer-common/assets/post-create.sh`: add NEXUS_DOCKER_URL mirror block after allow-list setup

## Testing
- Local devcontainer: set `NEXUS_DOCKER_URL=nexus-docker.lan.spruyt.xyz`, podman pulls route through Nexus
- Coder workspace: `NEXUS_DOCKER_URL` not injected, block skipped, existing ConfigMap mount unaffected
