### PR TITLE
fix(llm-guard): add /beta/litellm_basic_guardrail_api endpoint

### DIFF
--- a/llm-guard/app/main.py
+++ b/llm-guard/app/main.py
@@ -68,7 +68,9 @@ class _StructuredMsg(BaseModel):
 
 
 class LiteLLMRequest(BaseModel):
-    """Request body from a LiteLLM guardrail hook."""
+    """Request body from a LiteLLM guardrail hook (custom or generic API format)."""
+
+    model_config = {"extra": "ignore"}
 
     texts: list[str] = []
     structured_messages: list[_StructuredMsg] = []
@@ -90,6 +92,7 @@ def _safe_id(value: str) -> str:
 
 
 @app.post("/")
+@app.post("/beta/litellm_basic_guardrail_api")
 async def litellm_guardrail(req: LiteLLMRequest):
     """
     Evaluate a LiteLLM request for prompt injection.


### PR DESCRIPTION
## Problem

LiteLLM's "Generic Guardrail API" integration hits `/beta/litellm_basic_guardrail_api` — not `POST /`. Server returned 404.

## Fix

- Add `POST /beta/litellm_basic_guardrail_api` route (same handler as `POST /`)
- Add `model_config = {"extra": "ignore"}` to `LiteLLMRequest` so extra fields sent by LiteLLM (`input_type`, `request_data`, `model`, etc.) are silently ignored rather than causing validation errors

Both `POST /` and `POST /beta/litellm_basic_guardrail_api` remain supported.