### PR TITLE
fix(llm-guard): 422 on Generic Guardrail API (explicit nulls) + config-file-only

### DIFF
--- a/llm-guard/Dockerfile
+++ b/llm-guard/Dockerfile
@@ -13,16 +13,17 @@ COPY app/ .
 
 ENV HF_HOME=/app/.cache/huggingface
 
-# Pre-download model into HF cache
+# Pre-download the default model into the HF cache so the image runs offline.
 COPY assets/download_model.py /tmp/download_model.py
 RUN MODEL=${MODEL} python /tmp/download_model.py && rm /tmp/download_model.py
 
 RUN useradd -u 1000 -m appuser && chown -R 1000:1000 /app
 USER 1000:1000
 
-ENV MODEL=${MODEL}
-ENV INJECTION_LABEL=INJECTION
-ENV THRESHOLD=0.5
+# Scanner pipeline is configured via CONFIG_FILE (required). Default to the
+# baked-in single-scanner config; override by mounting a file and setting
+# CONFIG_FILE to its path (e.g. /config/scanners.yml).
+ENV CONFIG_FILE=/app/default-scanners.yml
 ENV LISTEN_HOST=0.0.0.0
 ENV LISTEN_PORT=8080
 

--- a/llm-guard/app/config.py
+++ b/llm-guard/app/config.py
@@ -14,11 +14,6 @@ DEFAULT_MODEL = "protectai/deberta-v3-base-prompt-injection-v2"
 DEFAULT_INJECTION_LABEL = "INJECTION"
 DEFAULT_THRESHOLD = 0.5
 
-# Backwards-compatible aliases referenced by scanner_types defaults.
-MODEL = DEFAULT_MODEL
-INJECTION_LABEL = DEFAULT_INJECTION_LABEL
-THRESHOLD = DEFAULT_THRESHOLD
-
 # --- Operational settings (environment-driven) ---
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "")
 LISTEN_HOST = os.environ.get("LISTEN_HOST", "0.0.0.0")

--- a/llm-guard/app/config.py
+++ b/llm-guard/app/config.py
@@ -1,35 +1,25 @@
-"""Configuration from environment variables."""
+"""Service configuration.
+
+Scanner behaviour (model, label, threshold, match type, …) is configured
+per-scanner in the CONFIG_FILE YAML, NOT via environment variables. The
+constants below are only fallback defaults used when a scanner omits the
+corresponding param. Only operational settings (bind address, config path)
+are read from the environment.
+"""
 import os
 
 
-MODEL = os.environ.get("MODEL", "protectai/deberta-v3-base-prompt-injection-v2")
-INJECTION_LABEL = os.environ.get("INJECTION_LABEL", "INJECTION")
+# --- Scanner fallback defaults (overridden per-scanner in CONFIG_FILE) ---
+DEFAULT_MODEL = "protectai/deberta-v3-base-prompt-injection-v2"
+DEFAULT_INJECTION_LABEL = "INJECTION"
+DEFAULT_THRESHOLD = 0.5
+
+# Backwards-compatible aliases referenced by scanner_types defaults.
+MODEL = DEFAULT_MODEL
+INJECTION_LABEL = DEFAULT_INJECTION_LABEL
+THRESHOLD = DEFAULT_THRESHOLD
+
+# --- Operational settings (environment-driven) ---
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "")
-
-
-def _parse_threshold() -> float:
-    """
-    Parse and validate the THRESHOLD environment variable.
-
-    Reads THRESHOLD from the environment (default "0.5"), converts it to a float,
-    and ensures the value is between 0.0 and 1.0 inclusive.
-
-    Returns:
-        float: Parsed threshold value between 0.0 and 1.0.
-
-    Raises:
-        ValueError: If THRESHOLD cannot be parsed as a float or is outside [0.0, 1.0].
-    """
-    raw = os.environ.get("THRESHOLD", "0.5")
-    try:
-        value = float(raw)
-    except ValueError as exc:
-        raise ValueError(f"THRESHOLD must be a float between 0 and 1, got: {raw!r}") from exc
-    if not 0.0 <= value <= 1.0:
-        raise ValueError(f"THRESHOLD must be between 0 and 1, got: {value}")
-    return value
-
-
-THRESHOLD = _parse_threshold()
 LISTEN_HOST = os.environ.get("LISTEN_HOST", "0.0.0.0")
 LISTEN_PORT = int(os.environ.get("LISTEN_PORT", "8080"))

--- a/llm-guard/app/default-scanners.yml
+++ b/llm-guard/app/default-scanners.yml
@@ -1,0 +1,11 @@
+# Default scanner pipeline baked into the image.
+#
+# Override by mounting your own file and pointing CONFIG_FILE at it
+# (e.g. CONFIG_FILE=/config/scanners.yml). This default uses only the
+# pre-baked PromptInjection model so the image runs fully offline.
+input_scanners:
+  - type: PromptInjection
+    params:
+      threshold: 0.5
+      match_type: full
+      model_max_length: 512

--- a/llm-guard/app/main.py
+++ b/llm-guard/app/main.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI
@@ -68,27 +69,33 @@ class _StructuredMsg(BaseModel):
 
 
 class LiteLLMRequest(BaseModel):
-    """Request body from a LiteLLM guardrail hook (custom or generic API format)."""
+    """Request body from a LiteLLM guardrail hook (custom or generic API format).
+
+    LiteLLM's Generic Guardrail API serialises the request with
+    ``model_dump(mode="json")``, so optional fields are sent as explicit
+    ``null`` rather than omitted. These fields must therefore be Optional —
+    a non-Optional ``list``/``str`` would reject the explicit null with a 422.
+    """
 
     model_config = {"extra": "ignore"}
 
-    texts: list[str] = []
-    structured_messages: list[_StructuredMsg] = []
-    litellm_call_id: str = ""
-    litellm_trace_id: str = ""
+    texts: Optional[list[str]] = None
+    structured_messages: Optional[list[_StructuredMsg]] = None
+    litellm_call_id: Optional[str] = None
+    litellm_trace_id: Optional[str] = None
 
 
 def _extract_prompt(req: LiteLLMRequest) -> str:
     """Build a single prompt string from a LiteLLM request."""
     if req.texts:
         return "\n".join(req.texts)
-    parts = [m.text() for m in req.structured_messages if m.role == "user"]
+    parts = [m.text() for m in (req.structured_messages or []) if m.role == "user"]
     return "\n".join(parts)
 
 
-def _safe_id(value: str) -> str:
-    """Strip newlines to prevent log injection."""
-    return value.replace("\n", " ").replace("\r", " ")
+def _safe_id(value: Optional[str]) -> str:
+    """Strip newlines to prevent log injection; treat None as empty."""
+    return (value or "").replace("\n", " ").replace("\r", " ")
 
 
 @app.post("/")

--- a/llm-guard/app/pipeline.py
+++ b/llm-guard/app/pipeline.py
@@ -1,4 +1,4 @@
-"""Scanner pipeline — loads from CONFIG_FILE or ENV defaults."""
+"""Scanner pipeline — loads from the CONFIG_FILE YAML (required)."""
 import logging
 from typing import Optional
 
@@ -44,11 +44,6 @@ def _build_from_config(path: str) -> list:
     return scanner_list
 
 
-def _build_from_env() -> list:
-    """Build default PromptInjection scanner from environment variables."""
-    return [PromptInjectionScanner()]
-
-
 class _Pipeline:
     """Ordered list of scanners run sequentially against each prompt."""
 
@@ -57,13 +52,16 @@ class _Pipeline:
         self._scanners: list = []
 
     def load(self):
-        """Load all configured scanners."""
-        if config.CONFIG_FILE:
-            logger.info("loading scanner config", extra={"path": config.CONFIG_FILE})
-            self._scanners = _build_from_config(config.CONFIG_FILE)
-        else:
-            logger.info("no CONFIG_FILE set, using ENV defaults")
-            self._scanners = _build_from_env()
+        """Load all configured scanners from the CONFIG_FILE YAML.
+
+        CONFIG_FILE is required: there is no ENV fallback. A missing or empty
+        value fails closed (RuntimeError) rather than silently serving an
+        unconfigured pipeline.
+        """
+        if not config.CONFIG_FILE:
+            raise RuntimeError("CONFIG_FILE is required but not set")
+        logger.info("loading scanner config", extra={"path": config.CONFIG_FILE})
+        self._scanners = _build_from_config(config.CONFIG_FILE)
 
         for scanner in self._scanners:
             scanner.load()

--- a/llm-guard/app/scanner_types.py
+++ b/llm-guard/app/scanner_types.py
@@ -50,7 +50,7 @@ class PromptInjectionScanner:
         self._model = kwargs.get("model", "") or config.DEFAULT_MODEL
         self._injection_label = kwargs.get("injection_label", "") or config.DEFAULT_INJECTION_LABEL
         threshold = kwargs.get("threshold", None)
-        self._threshold = config.THRESHOLD if threshold is None else threshold
+        self._threshold = config.DEFAULT_THRESHOLD if threshold is None else threshold
         self._match_type = kwargs.get("match_type", "full")
         self._model_max_length = kwargs.get("model_max_length", 512)
         self._pipe: Optional[Pipeline] = None

--- a/llm-guard/app/scanner_types.py
+++ b/llm-guard/app/scanner_types.py
@@ -41,14 +41,14 @@ class PromptInjectionScanner:
         Initialise the scanner from keyword arguments.
 
         Kwargs:
-            model (str): HuggingFace model ID. Defaults to config.MODEL.
-            injection_label (str): Positive-class label. Defaults to config.INJECTION_LABEL.
-            threshold (float): Block threshold [0,1]. Defaults to config.THRESHOLD.
+            model (str): HuggingFace model ID. Defaults to config.DEFAULT_MODEL.
+            injection_label (str): Positive-class label. Defaults to config.DEFAULT_INJECTION_LABEL.
+            threshold (float): Block threshold [0,1]. Defaults to config.DEFAULT_THRESHOLD.
             match_type (str): ``"full"`` or ``"sentence"``. Defaults to ``"full"``.
             model_max_length (int): Max token length. Defaults to 512.
         """
-        self._model = kwargs.get("model", "") or config.MODEL
-        self._injection_label = kwargs.get("injection_label", "") or config.INJECTION_LABEL
+        self._model = kwargs.get("model", "") or config.DEFAULT_MODEL
+        self._injection_label = kwargs.get("injection_label", "") or config.DEFAULT_INJECTION_LABEL
         threshold = kwargs.get("threshold", None)
         self._threshold = config.THRESHOLD if threshold is None else threshold
         self._match_type = kwargs.get("match_type", "full")
@@ -69,7 +69,7 @@ class PromptInjectionScanner:
         known_labels = set(self._pipe.model.config.label2id.keys())
         if self._injection_label not in known_labels:
             raise RuntimeError(
-                f"INJECTION_LABEL {self._injection_label!r} not in model labels: {known_labels}"
+                f"injection_label {self._injection_label!r} not in model labels: {known_labels}"
             )
         logger.info("model ready")
 

--- a/llm-guard/test.sh
+++ b/llm-guard/test.sh
@@ -89,5 +89,29 @@ if [ "$IS_VALID" != "True" ]; then
 fi
 echo "  /scan/prompt OK"
 
+echo "Test 7: Generic Guardrail API payload with explicit nulls (regression: 422)..."
+# LiteLLM serialises with model_dump(mode="json"), sending optional fields as
+# explicit null and using structured_messages instead of texts. Guards against
+# the 422 where non-Optional fields rejected explicit nulls.
+RESPONSE=$(curl -sf -X POST http://localhost:${PORT}/beta/litellm_basic_guardrail_api \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input_type": "request",
+    "texts": null,
+    "structured_messages": [{"role": "user", "content": "What is the capital of France?"}],
+    "litellm_call_id": null,
+    "litellm_trace_id": null,
+    "request_data": {},
+    "model": "gpt-4o",
+    "request_headers": null
+  }')
+ACTION=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['action'])")
+if [ "$ACTION" != "NONE" ]; then
+  echo "  ERROR: generic guardrail payload not handled. Response: $RESPONSE"
+  docker logs "$CONTAINER_NAME"
+  exit 1
+fi
+echo "  generic guardrail (explicit nulls) action=NONE OK"
+
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

Fixes the **HTTP 422** that disabled prompt-injection guarding in production: every real LiteLLM Generic Guardrail API call to `/beta/litellm_basic_guardrail_api` failed validation. Also removes the misleading ENV config path (no-op in CONFIG_FILE mode) and adds a regression test.

## Linked Issue

Closes #850

## Root cause

LiteLLM serialises with `model_dump(mode="json")` so optional fields are sent as explicit `null`, and the prompt arrives via `structured_messages` (not `texts`). The `LiteLLMRequest` model declared those fields non-Optional, so explicit nulls failed Pydantic v2 validation, returning 422. Confirmed by repro: the old schema raises `ValidationError` on `texts`/`litellm_call_id`/`litellm_trace_id`; the new schema parses and extracts the prompt correctly. `/scan/prompt` was unaffected, which hid the outage.

## Changes

- **main.py** — `texts`/`structured_messages`/`litellm_call_id`/`litellm_trace_id` become `Optional[...] = None`; null-safe `_extract_prompt` and `_safe_id`
- **pipeline.py** — config-file-only: removed ENV-default path; `CONFIG_FILE` required, fails closed if unset
- **config.py** — `MODEL`/`INJECTION_LABEL`/`THRESHOLD` demoted to fallback constants (were ignored in CONFIG_FILE mode); only operational env retained
- **Dockerfile** — bake `default-scanners.yml`, default `CONFIG_FILE` to it (image still runs standalone); dropped dead scanner env vars
- **test.sh** — new Test 7: explicit-null Generic Guardrail payload against `/beta/litellm_basic_guardrail_api`

## Testing

- `python -m py_compile` on all four modules: pass
- Pydantic repro in a venv: old schema raised `ValidationError` on 3 fields; new schema parses, `_extract_prompt` returns the user text; `texts`-only path still works
- New `test.sh` Test 7 covers the regression end-to-end in the CI image build/test

## Notes

This unblocks the spruyt-labs model swap: a mounted scanners.yml can now define `model` and `injection_label` per-scanner for a runtime-pulled model.
