### PR TITLE
fix(claude-agent-spruyt-labs): re-base on claude-agent-write [3/3]

### DIFF
--- a/claude-agent-spruyt-labs/Dockerfile
+++ b/claude-agent-spruyt-labs/Dockerfile
@@ -1,32 +1,16 @@
-FROM node:24-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf
+# claude-agent-spruyt-labs = claude-agent-write + Kubernetes/GitOps SRE tooling.
+# Pinned to a digest by Renovate once claude-agent-write publishes; until then
+# :latest resolves the most recent write build.
+# renovate: datasource=docker depName=ghcr.io/anthony-spruyt/claude-agent-write versioning=semver
+FROM ghcr.io/anthony-spruyt/claude-agent-write:latest
 
 # Ephemeral agent pod — lifespan managed by n8n spawner
 HEALTHCHECK NONE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# System deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates curl git openssh-client jq python3 python3-pip \
-  libnghttp2-14 \
-  && rm -rf /var/lib/apt/lists/*
-
-# GitHub CLI
-# renovate: depName=cli/cli datasource=github-releases
-ARG GH_VERSION="2.93.0"
-RUN ARCH="$(dpkg --print-architecture)" \
-  && curl -fsSL --retry 3 --retry-delay 5 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.deb" -o /tmp/gh.deb \
-  && dpkg -i /tmp/gh.deb \
-  && rm /tmp/gh.deb
-
-# ripgrep
-# renovate: depName=BurntSushi/ripgrep datasource=github-releases
-ARG RIPGREP_VERSION="15.1.0"
-RUN ARCH="$(dpkg --print-architecture)" \
-  && case "${ARCH}" in amd64) RG_ARCH="x86_64-unknown-linux-musl";; arm64) RG_ARCH="aarch64-unknown-linux-gnu";; *) echo "unsupported: ${ARCH}"; exit 1;; esac \
-  && curl -fsSL --retry 3 --retry-delay 5 \
-    "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-${RG_ARCH}.tar.gz" \
-  | tar -xz -C /usr/local/bin --strip-components=1 "ripgrep-${RIPGREP_VERSION}-${RG_ARCH}/rg"
+# SRE binaries install under /usr/local/bin — needs root.
+USER root
 
 # kubectl
 # renovate: depName=kubernetes/kubernetes datasource=github-releases
@@ -105,40 +89,9 @@ RUN ARCH="$(dpkg --print-architecture)" \
   && curl -fsSL --retry 3 --retry-delay 5 "https://github.com/falcosecurity/falcoctl/releases/download/${FALCOCTL_VERSION}/falcoctl_${FALCOCTL_VERSION_NUM}_linux_${ARCH}.tar.gz" \
   | tar -xz -C /usr/local/bin falcoctl
 
-# Go
-# renovate: depName=golang datasource=docker
-ARG GO_VERSION="1.26.3"
-RUN ARCH="$(dpkg --print-architecture)" \
-  && curl -fsSL --retry 3 --retry-delay 5 "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
-ENV PATH="/usr/local/go/bin:${PATH}"
-
-# Aikido safe-chain (installed globally, then set up for node user)
-# renovate: depName=@aikidosec/safe-chain datasource=npm
-ARG SAFE_CHAIN_VERSION="1.5.3"
-RUN npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION}"
-
-# agentmemory MCP (pre-installed so npx resolves locally without network fetch)
-# renovate: depName=@agentmemory/mcp datasource=npm
-ARG AGENTMEMORY_VERSION="0.9.22"
-RUN npm install -g "@agentmemory/mcp@${AGENTMEMORY_VERSION}"
-
-# Set up safe-chain shims for node user before any npm/pip calls
+# Helm plugins install into $HOME — run as the uid 1000 node user.
 USER 1000
-RUN safe-chain setup && safe-chain setup-ci
-ENV PATH="/home/node/.safe-chain/shims:${PATH}"
 
-# pre-commit
-# renovate: depName=pre-commit datasource=pypi
-ARG PRECOMMIT_VERSION="4.6.0"
-RUN pip install --no-cache-dir --break-system-packages pre-commit=="${PRECOMMIT_VERSION}"
-
-# Claude Code CLI (native binary — npm datasource tracks versions)
-# renovate: depName=@anthropic-ai/claude-code datasource=npm
-ARG CLAUDE_VERSION="2.1.158"
-RUN curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"
-ENV PATH="/home/node/.local/bin:${PATH}"
-
-# Helm plugins (installed as node user — helm stores plugins in $HOME)
 # renovate: depName=databus23/helm-diff datasource=github-releases
 ARG HELM_DIFF_VERSION="v3.15.7"
 RUN helm plugin install https://github.com/databus23/helm-diff --verify=false --version "${HELM_DIFF_VERSION}"

--- a/claude-agent-spruyt-labs/Dockerfile
+++ b/claude-agent-spruyt-labs/Dockerfile
@@ -2,7 +2,7 @@
 # Pinned to a digest by Renovate once claude-agent-write publishes; until then
 # :latest resolves the most recent write build.
 # renovate: datasource=docker depName=ghcr.io/anthony-spruyt/claude-agent-write versioning=semver
-FROM ghcr.io/anthony-spruyt/claude-agent-write:latest
+FROM ghcr.io/anthony-spruyt/claude-agent-write:1.0.41@sha256:2af705dd602560155e6f3111b1e1e1f0ec71315a3dffcd282390818ff89cde11
 
 # Ephemeral agent pod — lifespan managed by n8n spawner
 HEALTHCHECK NONE

--- a/claude-agent-spruyt-labs/README.md
+++ b/claude-agent-spruyt-labs/README.md
@@ -14,20 +14,7 @@ Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-a
 
 ## Contents (added on top of claude-agent-write)
 
-| Component       | Purpose                       |
-| --------------- | ----------------------------- |
-| kubectl         | Kubernetes API operations     |
-| kustomize       | Kustomize manifests           |
-| helm            | Chart management              |
-| helmfile        | Declarative helm management   |
-| helm-diff       | Helm diff plugin              |
-| helm-schema-gen | Helm schema generation plugin |
-| cilium          | Cilium CNI operations         |
-| talosctl        | Talos Linux node management   |
-| flux            | GitOps toolkit                |
-| velero          | Backup inspection             |
-| cnpg plugin     | CloudNativePG operations      |
-| falcoctl        | Falco security runtime        |
+Cluster/GitOps tooling such as kubectl, helm, and flux. See the [Dockerfile](./Dockerfile) for the complete installed list.
 
 ## Build
 

--- a/claude-agent-spruyt-labs/README.md
+++ b/claude-agent-spruyt-labs/README.md
@@ -1,38 +1,37 @@
 # claude-agent-spruyt-labs
 
-SRE investigation container for Claude Code agent pods spawned by n8n.
+Full read-write runtime container for Claude Code agent pods spawned by n8n to operate on the spruyt-labs cluster repo.
 
 ## Purpose
 
-Runtime image for Claude Code agents that investigate Kubernetes cluster state in spruyt-labs. Investigation only — no write operations. Each pod is spawned by n8n, performs a task, and terminates.
+Runtime image for Claude Code agents working on the spruyt-labs GitOps homelab. These agents both **investigate** cluster state and **make changes** — implement issues, fix and open PRs, commit code, run pre-commit hooks, and operate the Kubernetes/GitOps toolchain (kubectl, helm, flux, talosctl, etc.). Each pod is spawned by n8n, performs a task, and terminates.
 
-## Contents
+It is not investigation-only: it inherits the full write toolchain (Go, pre-commit) from `claude-agent-write` and adds the SRE/GitOps CLIs on top.
 
-| Component         | Purpose                       |
-| ----------------- | ----------------------------- |
-| Node.js           | Claude Code CLI dependency    |
-| Python 3          | Scripting support             |
-| git               | Repository operations         |
-| jq                | JSON processing               |
-| Claude Code CLI   | Core agent runtime            |
-| Aikido safe-chain | npm supply chain security     |
-| gh CLI            | GitHub API operations         |
-| ripgrep           | Fast recursive code search    |
-| kubectl           | Kubernetes API operations     |
-| kustomize         | Kustomize manifests           |
-| helm              | Chart management              |
-| helmfile          | Declarative helm management   |
-| helm-diff         | Helm diff plugin              |
-| helm-schema-gen   | Helm schema generation plugin |
-| cilium            | Cilium CNI operations         |
-| hubble            | Network observability         |
-| talosctl          | Talos Linux node management   |
-| flux              | GitOps toolkit                |
-| velero            | Backup inspection             |
-| cnpg plugin       | CloudNativePG operations      |
-| falcoctl          | Falco security runtime        |
+## Base image
+
+Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-agent-read`](../claude-agent-read)). The Ubuntu base, Node.js, Python 3, git, jq, gh, ripgrep, safe-chain, agentmemory, Claude Code CLI, Go, and pre-commit all come from that chain. This image adds only the cluster tooling delta.
+
+## Contents (added on top of claude-agent-write)
+
+| Component       | Purpose                       |
+| --------------- | ----------------------------- |
+| kubectl         | Kubernetes API operations     |
+| kustomize       | Kustomize manifests           |
+| helm            | Chart management              |
+| helmfile        | Declarative helm management   |
+| helm-diff       | Helm diff plugin              |
+| helm-schema-gen | Helm schema generation plugin |
+| cilium          | Cilium CNI operations         |
+| talosctl        | Talos Linux node management   |
+| flux            | GitOps toolkit                |
+| velero          | Backup inspection             |
+| cnpg plugin     | CloudNativePG operations      |
+| falcoctl        | Falco security runtime        |
 
 ## Build
+
+`claude-agent-spruyt-labs` is `FROM ghcr.io/anthony-spruyt/claude-agent-write`, so a published `claude-agent-write` image is required.
 
 ```bash
 docker build -t claude-agent-spruyt-labs claude-agent-spruyt-labs/

--- a/claude-agent-spruyt-labs/test.sh
+++ b/claude-agent-spruyt-labs/test.sh
@@ -19,6 +19,7 @@ for bin in claude node python3 git npm jq gh rg go pre-commit \
 done
 
 claude --version
+node -e "console.log(\"OK: node executes\")"
 safe-chain --version
 gh --version
 rg --version
@@ -33,6 +34,34 @@ helm plugin list | grep -q diff || { echo "FAIL: helm-diff plugin not found"; ex
 echo "OK: helm-diff plugin installed"
 helm plugin list | grep -q schema-gen || { echo "FAIL: helm-schema-gen plugin not found"; exit 1; }
 echo "OK: helm-schema-gen plugin installed"
+
+# Functional pre-commit test that actually installs hook environments.
+# Uses a node-language hook (markdownlint) and a python-language hook
+# (end-of-file-fixer) so pre-commit builds and runs real node + python hook
+# envs — not a "language: system / echo" no-op. This exercises the full path
+# agents depend on (clone hook repo, build env, run hook).
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+git init -q
+git config user.email "test@test"
+git config user.name "test"
+cat > .pre-commit-config.yaml <<EOF
+repos:
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+EOF
+printf "# Title\n\nContent.\n" > README.md
+git add .
+pre-commit run --all-files
+echo "OK: pre-commit functional test passed (node + python hook envs built and ran)"
+cd /
+rm -rf "$TMPDIR"
 
 echo "All tests passed."
 '


### PR DESCRIPTION
Stage 3 of 3 of the shared ubuntu chain re-base.

> **Stacked on #852** (base branch = `fix/claude-agent-ubuntu-base-write`). Merge #849 then #852 first; this PR retargets to `main` automatically once #852 lands.

## Linked Issue
Closes #848

## Changes
- `claude-agent-spruyt-labs/Dockerfile`: now `FROM ghcr.io/anthony-spruyt/claude-agent-write`. Drops the entire duplicated node/python/go/pre-commit/claude/safe-chain/agentmemory toolchain; keeps only the SRE delta (kubectl, kustomize, helm, helmfile, cilium, talosctl, flux, velero, kubectl-cnpg, falcoctl, helm-diff, helm-schema-gen).
- `claude-agent-spruyt-labs/README.md`: **corrected** — it claimed "SRE investigation container … investigation only, no write operations", which is wrong (these agents implement issues, fix PRs, commit code). Rewritten as a full read-write agent image. Also removed `hubble` from the contents table — no hubble binary was ever installed.
- `claude-agent-spruyt-labs/test.sh`: same functional pre-commit improvement (real node + python hook envs).

## Before merge
After #852 merges and `claude-agent-write` publishes, pin the `FROM` digest (`:latest` → `@sha256:…`); Renovate also manages this via the annotation.

## Testing
- hadolint + shellcheck clean
- Full image build + SRE binary checks + functional pre-commit test run in CI