### PR TITLE
fix(llm-guard): startup crash when model config.label2id is None

### DIFF
--- a/llm-guard/app/scanner_types.py
+++ b/llm-guard/app/scanner_types.py
@@ -66,12 +66,31 @@ class PromptInjectionScanner:
             max_length=self._model_max_length,
             top_k=None,
         )
-        known_labels = set(self._pipe.model.config.label2id.keys())
-        if self._injection_label not in known_labels:
+        known_labels = self._known_labels()
+        if known_labels and self._injection_label not in known_labels:
             raise RuntimeError(
                 f"injection_label {self._injection_label!r} not in model labels: {known_labels}"
             )
+        if not known_labels:
+            # Some models populate only one of label2id/id2label, or neither
+            # (e.g. generic LABEL_0/LABEL_1). Can't validate up front; the
+            # label is resolved per-inference from pipeline output instead.
+            logger.warning(
+                "model exposes no label map; skipping injection_label validation",
+                extra={"injection_label": self._injection_label},
+            )
         logger.info("model ready")
+
+    def _known_labels(self) -> set:
+        """Return the model's label names from label2id or id2label, if any."""
+        cfg = self._pipe.model.config
+        label2id = getattr(cfg, "label2id", None)
+        if label2id:
+            return set(label2id.keys())
+        id2label = getattr(cfg, "id2label", None)
+        if id2label:
+            return set(id2label.values())
+        return set()
 
     def _score_text(self, text: str) -> float:
         """Return injection score [0,1] for a single text chunk."""

--- a/llm-guard/app/scanner_types.py
+++ b/llm-guard/app/scanner_types.py
@@ -54,6 +54,7 @@ class PromptInjectionScanner:
         self._match_type = kwargs.get("match_type", "full")
         self._model_max_length = kwargs.get("model_max_length", 512)
         self._pipe: Optional[Pipeline] = None
+        self._injection_label_missing_warned = False
 
     def load(self):
         """Load the HuggingFace pipeline and validate the injection label exists."""
@@ -99,6 +100,15 @@ class PromptInjectionScanner:
         results = self._pipe(text)
         flat = results[0] if results and isinstance(results[0], list) else results
         scores = {r["label"]: r["score"] for r in flat}
+        if self._injection_label not in scores and not self._injection_label_missing_warned:
+            # Fail-open: a missing label means every prompt scores 0.0. Warn
+            # once so the silent pass-through is observable at runtime.
+            logger.warning(
+                "injection_label not in model output; scanner fails open (scores 0.0)",
+                extra={"injection_label": self._injection_label,
+                       "model_labels": sorted(scores.keys())},
+            )
+            self._injection_label_missing_warned = True
         return scores.get(self._injection_label, 0.0)
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes a startup crash (`AttributeError: 'NoneType' object has no attribute 'keys'`) when loading a model whose `config.label2id` is `None`. Blocks the spruyt-labs swap to `rogue-security/prompt-injection-jailbreak-sentinel-v2`.

## Linked Issue

Closes #858

## Root cause

`PromptInjectionScanner.load()` did `set(self._pipe.model.config.label2id.keys())`. The rogue-security model (Qwen3-0.6B seq-classification) loads fine and emits the `jailbreak` label at inference, but its `label2id` is unset — the label map is in `id2label`. The unconditional `.keys()` crashed lifespan startup → pod never becomes ready.

## Changes

- `scanner_types.py`: resolve known labels from `label2id`, else `id2label.values()`; if neither present, log a warning and skip up-front validation (label still resolved per-inference from pipeline output).

## Testing

- `py_compile`: pass
- Logic: `label2id` present → unchanged behaviour; `label2id=None` + `id2label` present (this model) → labels from `id2label.values()`, `jailbreak` validates; neither → warn + continue instead of crash.

## Follow-up risk (noted in #858)

If a model exposes neither map, the configured `injection_label` never matches output and prompts score 0.0 (fail-open). Not the case here; future hardening could fail closed.
