### PR TITLE
chore(agentmemory): yeet agent memory

### DIFF
--- a/claude-agent-read/Dockerfile
+++ b/claude-agent-read/Dockerfile
@@ -51,11 +51,6 @@ RUN npm install -g "@aikidosec/safe-chain@${SAFE_CHAIN_VERSION}" \
   && if getent passwd 1000 >/dev/null; then userdel -r "$(getent passwd 1000 | cut -d: -f1)"; fi \
   && useradd -m -u 1000 -s /bin/bash node
 
-# agentmemory MCP (pre-installed so npx resolves locally without network fetch)
-# renovate: depName=@agentmemory/mcp datasource=npm
-ARG AGENTMEMORY_VERSION="0.9.22"
-RUN npm install -g "@agentmemory/mcp@${AGENTMEMORY_VERSION}"
-
 # Set up safe-chain shims for node user before any npm/pip calls
 USER 1000
 RUN safe-chain setup && safe-chain setup-ci

--- a/claude-agent-spruyt-labs/README.md
+++ b/claude-agent-spruyt-labs/README.md
@@ -10,7 +10,7 @@ It is not investigation-only: it inherits the full write toolchain (Go, pre-comm
 
 ## Base image
 
-Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-agent-read`](../claude-agent-read)). The Ubuntu base, Node.js, Python 3, git, jq, gh, ripgrep, safe-chain, agentmemory, Claude Code CLI, Go, and pre-commit all come from that chain. This image adds only the cluster tooling delta.
+Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-agent-read`](../claude-agent-read)). The Ubuntu base, Node.js, Python 3, git, jq, gh, ripgrep, safe-chain, Claude Code CLI, Go, and pre-commit all come from that chain. This image adds only the cluster tooling delta.
 
 ## Contents (added on top of claude-agent-write)
 

--- a/claude-agent-spruyt-labs/README.md
+++ b/claude-agent-spruyt-labs/README.md
@@ -10,7 +10,7 @@ It is not investigation-only: it inherits the full write toolchain (Go, pre-comm
 
 ## Base image
 
-Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-agent-read`](../claude-agent-read)). The Ubuntu base, Node.js, Python 3, git, jq, gh, ripgrep, safe-chain, Claude Code CLI, Go, and pre-commit all come from that chain. This image adds only the cluster tooling delta.
+Built on [`claude-agent-write`](../claude-agent-write) (itself `FROM` [`claude-agent-read`](../claude-agent-read)). Core runtime layers (e.g., language runtimes, developer tooling, and agent CLI dependencies) come from that chain. This image adds only the cluster tooling delta.
 
 ## Contents (added on top of claude-agent-write)
 


### PR DESCRIPTION
Delete agent memory as we will be replacing it with https://github.com/vectorize-io/hindsight as middleware in litellm