### PR TITLE
feat(llm-guard): split into CPU and CUDA variants

### DIFF
--- a/.github/workflows/_image-pipeline.yaml
+++ b/.github/workflows/_image-pipeline.yaml
@@ -281,9 +281,30 @@ jobs:
               cp "$IMAGE_NAME/Dockerfile" upstream/Dockerfile
             fi
             echo "path=upstream" >> "$GITHUB_OUTPUT"
-          else
-            echo "path=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+            echo "dockerfile=upstream/Dockerfile" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Optional build_context: build against another image's directory
+          # using this image's own Dockerfile (variant images sharing sources).
+          BUILD_CONTEXT=$(yq -r '.build_context // ""' "$IMAGE_NAME/metadata.yaml")
+          if [ -n "$BUILD_CONTEXT" ]; then
+            if ! echo "$BUILD_CONTEXT" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+              echo "::error::Invalid build_context format in $IMAGE_NAME/metadata.yaml: $BUILD_CONTEXT"
+              exit 1
+            fi
+            if [ ! -d "$BUILD_CONTEXT" ]; then
+              echo "::error::build_context directory does not exist: $BUILD_CONTEXT"
+              exit 1
+            fi
+            echo "::notice::Building $IMAGE_NAME from context $BUILD_CONTEXT"
+            echo "path=$BUILD_CONTEXT" >> "$GITHUB_OUTPUT"
+            echo "dockerfile=$IMAGE_NAME/Dockerfile" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "path=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "dockerfile=$IMAGE_NAME/Dockerfile" >> "$GITHUB_OUTPUT"
 
       - name: Generate flavor files
         env:
@@ -297,10 +318,10 @@ jobs:
 
       - name: Verify Dockerfile exists
         env:
-          CONTEXT_PATH: ${{ steps.context.outputs.path }}
+          DOCKERFILE: ${{ steps.context.outputs.dockerfile }}
         run: |
-          if [ ! -f "$CONTEXT_PATH/Dockerfile" ]; then
-            echo "::error::No Dockerfile found at $CONTEXT_PATH/Dockerfile"
+          if [ ! -f "$DOCKERFILE" ]; then
+            echo "::error::No Dockerfile found at $DOCKERFILE"
             exit 1
           fi
 
@@ -330,6 +351,7 @@ jobs:
         uses: docker/build-push-action@83bfd93ab480705a7b99a2ed02765137f5ab55ba
         with:
           context: ${{ steps.context.outputs.path }}
+          file: ${{ steps.context.outputs.dockerfile }}
           push: false
           load: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
@@ -389,6 +411,7 @@ jobs:
         uses: docker/build-push-action@83bfd93ab480705a7b99a2ed02765137f5ab55ba
         with:
           context: ${{ steps.context.outputs.path }}
+          file: ${{ steps.context.outputs.dockerfile }}
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,24 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_IMAGE: ${{ inputs.image }}
         run: |
+          # Variant images build from another image's directory via
+          # build_context in metadata.yaml and may have no sources of their
+          # own, so a change to the source directory must fan out to them.
+          add_build_context_dependents() {
+            local changed="$1"
+            local dependents=""
+            for metadata in */metadata.yaml; do
+              local ctx dir
+              ctx=$(yq -r '.build_context // ""' "$metadata")
+              [ -n "$ctx" ] || continue
+              dir="${metadata%/metadata.yaml}"
+              if echo "$changed" | grep -qxF "$ctx"; then
+                dependents="${dependents}${dir}"$'\n'
+              fi
+            done
+            printf '%s\n%s' "$changed" "$dependents" | sort -u | grep -v '^$' || true
+          }
+
           # Detect CI script changes (for test-ci-scripts job)
           detect_scripts() {
             local diff_cmd="$1"
@@ -118,6 +136,7 @@ jobs:
               grep -E '^[a-zA-Z0-9_-]+/(Dockerfile|test\.sh|assets/|app/|metadata\.yaml|flavor\.yaml)' | \
               cut -d'/' -f1 | sort -u | \
               while read -r img; do if [ -d "$img" ]; then echo "$img"; fi; done)
+            DIRECT_CHANGES=$(add_build_context_dependents "$DIRECT_CHANGES")
 
             # If megalinter-factory changed, add all flavor directories
             if echo "$DIFF_FILES" | grep -qE '^megalinter-factory/'; then
@@ -144,6 +163,7 @@ jobs:
               grep -E '^[a-zA-Z0-9_-]+/(Dockerfile|metadata\.yaml|flavor\.yaml|assets/|app/)' | \
               cut -d'/' -f1 | sort -u | \
               while read -r img; do if [ -d "$img" ]; then echo "$img"; fi; done)
+            DIRECT_CHANGES=$(add_build_context_dependents "$DIRECT_CHANGES")
 
             # If megalinter-factory changed, add all flavor directories
             if echo "$DIFF_FILES" | grep -qE '^megalinter-factory/'; then

--- a/.trivy-images.yaml
+++ b/.trivy-images.yaml
@@ -8,6 +8,7 @@ images:
   - "coder-gitops"
   - "devcontainer-common"
   - "llm-guard"
+  - "llm-guard-cuda"
   - "megalinter-container-images"
   - "megalinter-firemerge"
   - "megalinter-factory"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,18 @@ auto_patch: true
 
 CI appends `.N` automatically (e.g., `1.1.0`, `1.1.1`, `1.1.2`). Do **not** include the patch segment in `version` — writing `"1.1.0"` with `auto_patch: true` would produce `1.1.0.0`.
 
+### Option 4: Variant of an existing image (`build_context`)
+
+For a variant that shares another image's sources but needs its own Dockerfile, set `build_context` to that image's directory. The variant directory then only needs a `Dockerfile` (plus optionally `test.sh`) — no copy of the shared `app/` or `assets/`:
+
+```yaml
+version: "1.0"
+auto_patch: true
+build_context: llm-guard
+```
+
+CI builds with `context: <build_context>` and `file: <image-name>/Dockerfile`, and change detection fans out — a change in the source directory rebuilds the variant too. `build_context` is ignored when the image also has an `upstream` (the upstream checkout wins).
+
 ### That's It
 
 - **No workflow updates needed** - upstream validation uses each image's own `metadata.yaml`

--- a/llm-guard-cuda/Dockerfile
+++ b/llm-guard-cuda/Dockerfile
@@ -10,11 +10,16 @@ WORKDIR /app
 # --index-url replaces PyPI wholesale, and the PyTorch index does not serve
 # fastapi, uvicorn, transformers or pyyaml. Torch first also keeps the
 # largest, most cache-stable layer at the bottom.
+#
+# --only-binary :all: refuses source distributions outright: every dependency
+# here publishes a cp314/abi3 manylinux wheel, so a missing wheel means a
+# resolution mistake and should fail the build rather than silently run an
+# arbitrary setup.py at image-build time.
 COPY app/requirements-cuda.txt .
-RUN pip install --no-cache-dir -r requirements-cuda.txt
+RUN pip install --no-cache-dir --only-binary :all: -r requirements-cuda.txt
 
 COPY app/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --only-binary :all: -r requirements.txt
 
 COPY app/ .
 

--- a/llm-guard-cuda/Dockerfile
+++ b/llm-guard-cuda/Dockerfile
@@ -4,13 +4,14 @@ FROM python:${PYTHON_VERSION}
 
 WORKDIR /app
 
-# torch is installed first and from its own requirements file: --index-url
-# replaces PyPI wholesale, and the PyTorch index does not serve fastapi,
-# uvicorn, transformers or pyyaml. Torch first also keeps the largest, most
-# cache-stable layer at the bottom and splits what used to be one 2.7GB layer
-# into two, which containerd can pull in parallel.
-COPY app/requirements-cpu.txt .
-RUN pip install --no-cache-dir -r requirements-cpu.txt
+# Built from the llm-guard/ build context (metadata.yaml build_context), so
+# app/ is shared with the CPU image and only the torch requirements file
+# differs. torch is installed first and from its own requirements file:
+# --index-url replaces PyPI wholesale, and the PyTorch index does not serve
+# fastapi, uvicorn, transformers or pyyaml. Torch first also keeps the
+# largest, most cache-stable layer at the bottom.
+COPY app/requirements-cuda.txt .
+RUN pip install --no-cache-dir -r requirements-cuda.txt
 
 COPY app/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/llm-guard-cuda/metadata.yaml
+++ b/llm-guard-cuda/metadata.yaml
@@ -1,0 +1,6 @@
+---
+version: "1.0"
+auto_patch: true
+# Build from llm-guard/ so app/ is shared; only this directory's Dockerfile
+# (CUDA torch wheel) differs.
+build_context: llm-guard

--- a/llm-guard-cuda/test.sh
+++ b/llm-guard-cuda/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Test script for llm-guard-cuda container.
+# The image is byte-identical to llm-guard apart from the torch wheel, so the
+# assertions live in llm-guard/test.sh and this only selects the cuda flavor.
+# Usage: ./test.sh <image-ref>
+
+set -euo pipefail
+
+exec "$(dirname "$0")/../llm-guard/test.sh" "${1:?Usage: $0 <image-ref>}" cuda

--- a/llm-guard/Dockerfile
+++ b/llm-guard/Dockerfile
@@ -9,11 +9,15 @@ WORKDIR /app
 # uvicorn, transformers or pyyaml. Torch first also keeps the largest, most
 # cache-stable layer at the bottom and splits what used to be one 2.7GB layer
 # into two, which containerd can pull in parallel.
+# --only-binary :all: refuses source distributions outright: every dependency
+# here publishes a cp314/abi3 manylinux wheel, so a missing wheel means a
+# resolution mistake and should fail the build rather than silently run an
+# arbitrary setup.py at image-build time.
 COPY app/requirements-cpu.txt .
-RUN pip install --no-cache-dir -r requirements-cpu.txt
+RUN pip install --no-cache-dir --only-binary :all: -r requirements-cpu.txt
 
 COPY app/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --only-binary :all: -r requirements.txt
 
 COPY app/ .
 

--- a/llm-guard/app/config.py
+++ b/llm-guard/app/config.py
@@ -18,3 +18,7 @@ DEFAULT_THRESHOLD = 0.5
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "")
 LISTEN_HOST = os.environ.get("LISTEN_HOST", "0.0.0.0")
 LISTEN_PORT = int(os.environ.get("LISTEN_PORT", "8080"))
+# Inference device index passed to the transformers pipeline: "-1" for CPU,
+# "0" (or higher) for a specific GPU. Empty means auto-detect — CUDA if the
+# installed torch build exposes it, CPU otherwise.
+SCANNER_DEVICE = os.environ.get("SCANNER_DEVICE", "")

--- a/llm-guard/app/requirements-cpu.txt
+++ b/llm-guard/app/requirements-cpu.txt
@@ -1,0 +1,5 @@
+# --index-url REPLACES PyPI, so the CUDA build is unreachable from here.
+# Do not switch to --extra-index-url: pip could resolve torch from PyPI
+# and pull the ~2.5GB nvidia-*/triton dependency set back in.
+--index-url https://download.pytorch.org/whl/cpu
+torch==2.13.0

--- a/llm-guard/app/requirements-cuda.txt
+++ b/llm-guard/app/requirements-cuda.txt
@@ -1,0 +1,5 @@
+# --index-url REPLACES PyPI, so the resolved build is always the CUDA one
+# from this index. cu130 matches what default PyPI resolves to, so this
+# reproduces the pre-split image exactly.
+--index-url https://download.pytorch.org/whl/cu130
+torch==2.13.0

--- a/llm-guard/app/requirements.txt
+++ b/llm-guard/app/requirements.txt
@@ -1,6 +1,5 @@
 fastapi==0.141.1
 uvicorn[standard]==0.52.4
 transformers==5.15.0
-torch==2.13.0
 pydantic==2.13.4
 pyyaml==6.0.3

--- a/llm-guard/app/scanner_types.py
+++ b/llm-guard/app/scanner_types.py
@@ -4,6 +4,7 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from typing import Optional
+import torch
 from transformers import Pipeline, pipeline
 
 import config
@@ -21,6 +22,19 @@ _INVISIBLE_CODEPOINTS = frozenset({
     0x2060,  # word joiner
     0xFEFF,  # zero-width no-break space / BOM
 })
+
+
+def _resolve_device() -> int:
+    """
+    Return the transformers pipeline device index.
+
+    ``config.SCANNER_DEVICE`` wins when set. Otherwise auto-detect: the CUDA
+    image ships a CUDA torch build and lands on GPU 0, while the CPU image
+    ships the CPU-only wheel, reports ``is_available()`` False, and stays on -1.
+    """
+    if config.SCANNER_DEVICE:
+        return int(config.SCANNER_DEVICE)
+    return 0 if torch.cuda.is_available() else -1
 
 
 @dataclass
@@ -58,11 +72,14 @@ class PromptInjectionScanner:
 
     def load(self):
         """Load the HuggingFace pipeline and validate the injection label exists."""
-        logger.info("loading model", extra={"model": self._model})
+        device = _resolve_device()
+        # Device goes in msg, not extra: the logging.basicConfig format in
+        # main.py only renders %(message)s, so extra= fields never surface.
+        logger.info("loading model on device %s", device, extra={"model": self._model})
         self._pipe = pipeline(
             "text-classification",
             model=self._model,
-            device=-1,
+            device=device,
             truncation=True,
             max_length=self._model_max_length,
             top_k=None,

--- a/llm-guard/test.sh
+++ b/llm-guard/test.sh
@@ -142,13 +142,13 @@ echo "Test 8: torch build matches flavor ($FLAVOR)..."
 # Direct regression guard for the image-size split: the CPU image must never
 # ship the CUDA wheel. torch.version.cuda is None on a +cpu build.
 TORCH_CUDA=$(docker exec "$CONTAINER_NAME" python -c "import torch; print(torch.version.cuda)")
-if [ "$FLAVOR" = "cpu" ]; then
-  if [ "$TORCH_CUDA" != "None" ]; then
+if [[ "$FLAVOR" == "cpu" ]]; then
+  if [[ "$TORCH_CUDA" != "None" ]]; then
     echo "  ERROR: CPU image contains a CUDA torch build (torch.version.cuda=$TORCH_CUDA)" >&2
     exit 1
   fi
 else
-  if [ "$TORCH_CUDA" = "None" ]; then
+  if [[ "$TORCH_CUDA" == "None" ]]; then
     echo "  ERROR: CUDA image contains a CPU-only torch build (torch.version.cuda=None)" >&2
     exit 1
   fi
@@ -165,10 +165,10 @@ if ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q 'loading model on device -1'; 
 fi
 echo "  device=-1 OK"
 
-if [ "$FLAVOR" = "cpu" ]; then
+if [[ "$FLAVOR" == "cpu" ]]; then
   echo "Test 10: image size under ceiling..."
   IMAGE_BYTES=$(docker image inspect "$IMAGE_REF" --format '{{.Size}}')
-  if [ "$IMAGE_BYTES" -ge "$MAX_CPU_IMAGE_BYTES" ]; then
+  if [[ "$IMAGE_BYTES" -ge "$MAX_CPU_IMAGE_BYTES" ]]; then
     echo "  ERROR: image is ${IMAGE_BYTES} bytes, ceiling is ${MAX_CPU_IMAGE_BYTES}" >&2
     exit 1
   fi

--- a/llm-guard/test.sh
+++ b/llm-guard/test.sh
@@ -158,9 +158,14 @@ echo "  torch.version.cuda=$TORCH_CUDA OK"
 echo "Test 9: device resolution logged..."
 # CI runners have no GPU, so both flavors must resolve to -1. Catches
 # _resolve_device() throwing or mis-parsing SCANNER_DEVICE.
-if ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q 'loading model on device -1'; then
+# Logs are captured to a variable rather than piped into grep: under
+# `set -o pipefail`, `grep -q` exits on the first match, `docker logs` then
+# takes SIGPIPE and exits 141, and the pipeline reports failure even though
+# the line was found.
+CONTAINER_LOGS=$(docker logs "$CONTAINER_NAME" 2>&1)
+if ! grep -q 'loading model on device -1' <<<"$CONTAINER_LOGS"; then
   echo "  ERROR: expected 'loading model on device -1' in logs" >&2
-  docker logs "$CONTAINER_NAME"
+  echo "$CONTAINER_LOGS"
   exit 1
 fi
 echo "  device=-1 OK"

--- a/llm-guard/test.sh
+++ b/llm-guard/test.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 # Test script for llm-guard container
-# Usage: ./test.sh <image-ref>
+# Usage: ./test.sh <image-ref> [flavor]
+#   flavor: cpu (default) or cuda — selects the torch build assertions.
+#           llm-guard-cuda/test.sh passes "cuda".
 
 set -euo pipefail
 
-IMAGE_REF="${1:?Usage: $0 <image-ref>}"
+IMAGE_REF="${1:?Usage: $0 <image-ref> [cpu|cuda]}"
+FLAVOR="${2:-cpu}"
+if [[ "$FLAVOR" != "cpu" && "$FLAVOR" != "cuda" ]]; then
+  echo "ERROR: unknown flavor '$FLAVOR' (expected cpu or cuda)" >&2
+  exit 1
+fi
 CONTAINER_NAME="llm-guard-test-$$"
 PORT=8080
+
+# Uncompressed size ceiling for the CPU image. The pre-split image (CUDA torch
+# pulled in from default PyPI) was ~7GB uncompressed, so this fails loudly if
+# the CUDA wheel ever comes back into the CPU variant.
+MAX_CPU_IMAGE_BYTES=$((2500 * 1000 * 1000))
 
 # cleanup removes the Docker container named by CONTAINER_NAME (if present) and suppresses any errors.
 cleanup() {
@@ -17,6 +29,7 @@ trap cleanup EXIT
 
 echo "=== LLM Guard Container Tests ==="
 echo "Image: $IMAGE_REF"
+echo "Flavor: $FLAVOR"
 echo ""
 
 echo "Test 1: Container startup..."
@@ -124,6 +137,43 @@ if [ "$ACTION" != "NONE" ]; then
   exit 1
 fi
 echo "  generic guardrail (explicit nulls) action=NONE OK"
+
+echo "Test 8: torch build matches flavor ($FLAVOR)..."
+# Direct regression guard for the image-size split: the CPU image must never
+# ship the CUDA wheel. torch.version.cuda is None on a +cpu build.
+TORCH_CUDA=$(docker exec "$CONTAINER_NAME" python -c "import torch; print(torch.version.cuda)")
+if [ "$FLAVOR" = "cpu" ]; then
+  if [ "$TORCH_CUDA" != "None" ]; then
+    echo "  ERROR: CPU image contains a CUDA torch build (torch.version.cuda=$TORCH_CUDA)" >&2
+    exit 1
+  fi
+else
+  if [ "$TORCH_CUDA" = "None" ]; then
+    echo "  ERROR: CUDA image contains a CPU-only torch build (torch.version.cuda=None)" >&2
+    exit 1
+  fi
+fi
+echo "  torch.version.cuda=$TORCH_CUDA OK"
+
+echo "Test 9: device resolution logged..."
+# CI runners have no GPU, so both flavors must resolve to -1. Catches
+# _resolve_device() throwing or mis-parsing SCANNER_DEVICE.
+if ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q 'loading model on device -1'; then
+  echo "  ERROR: expected 'loading model on device -1' in logs" >&2
+  docker logs "$CONTAINER_NAME"
+  exit 1
+fi
+echo "  device=-1 OK"
+
+if [ "$FLAVOR" = "cpu" ]; then
+  echo "Test 10: image size under ceiling..."
+  IMAGE_BYTES=$(docker image inspect "$IMAGE_REF" --format '{{.Size}}')
+  if [ "$IMAGE_BYTES" -ge "$MAX_CPU_IMAGE_BYTES" ]; then
+    echo "  ERROR: image is ${IMAGE_BYTES} bytes, ceiling is ${MAX_CPU_IMAGE_BYTES}" >&2
+    exit 1
+  fi
+  echo "  ${IMAGE_BYTES} bytes (ceiling ${MAX_CPU_IMAGE_BYTES}) OK"
+fi
 
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
Closes #1360.

## Problem

`ghcr.io/anthony-spruyt/llm-guard:1.0.23` is 2,774 MiB compressed, with a single 2,732 MiB layer accounting for 98.5% of it:

```
  28 MiB  26c307b5e35a   python:3.14-slim base
   1 MiB  dffb4b798a6d
  11 MiB  e757cd4ee070
   0 MiB  (3 layers)
2732 MiB  de034c00db60   <- RUN pip install -r requirements.txt
   0 MiB  (2 layers)
```

Model weights are already out of the image — that removal is what took 1.0.14 from 4,073 MiB down to 2,774 MiB. The remaining bulk is `torch==2.13.0` resolving from default PyPI to the **CUDA** build (502 MiB wheel), which additionally declares `nvidia-cudnn-cu13`, `nvidia-cusparselt-cu13`, `nvidia-nccl-cu13`, `nvidia-nvshmem-cu13` and `triton` — all gated only on `platform_system == "Linux"`, with no GPU condition.

A cold pull onto a cluster node measured 15m8s, which forced `spruyt-labs` to raise HelmRelease/Kustomization timeouts from 15m to 30m (anthony-spruyt/spruyt-labs#2591) after a 15m timeout caused a release-wide Helm rollback.

## Change

Two images from one source tree:

| Image | torch wheel | Consumer |
| --- | --- | --- |
| `llm-guard` | `2.13.0+cpu` (183 MiB wheel) | our cluster |
| `llm-guard-cuda` | `2.13.0+cu130` (502 MiB wheel) | GPU consumers |

`cu130` is what default PyPI resolves to today, so the CUDA variant reproduces current behaviour exactly.

### torch in its own requirements file

`--index-url` **replaces** PyPI rather than supplementing it, and the PyTorch index 403s on `fastapi`, `uvicorn`, `transformers` and `pyyaml` — so torch has to be installed in a separate step from its own file. `--extra-index-url` is deliberately not used: pip could still resolve torch from PyPI and pull the ~2.5 GB nvidia/triton set back in.

This also splits the one giant layer into two, which containerd can pull in parallel.

File naming matters for Renovate: `pip_requirements` matches `/(^|/)[\w-]*requirements([-._]\w+)?\.(txt|pip)$/`, so `requirements-cpu.txt` matches but `requirements-torch-cpu.txt` would not (`\w` excludes `-`). Renovate parses `--index-url` into `registryUrls`, so each pin is bumped against the correct PyTorch index. The pin stays a plain `torch==2.13.0` — PEP 440 `==2.13.0` matches `2.13.0+cpu`, the CPU index serves only `+cpu` wheels, and a plain pin is one Renovate will actually bump.

### Device resolution

`scanner_types.py` hardcoded `device=-1`, which would have made the CUDA image a large CPU image. It now resolves from a new `SCANNER_DEVICE` env var when set, otherwise auto-detects via `torch.cuda.is_available()`. The CPU image is unaffected — the CPU wheel reports `is_available()` False and stays at -1.

The device is logged in the message body rather than via `extra=`, which the `logging.basicConfig` format in `main.py` discards.

### `build_context` in metadata.yaml

`llm-guard-cuda/` carries **no copy of `app/`** (515 lines of Python). A new optional `build_context` key lets an image build against another image's directory using its own Dockerfile:

```yaml
version: "1.0"
auto_patch: true
build_context: llm-guard
```

CI builds with `context: llm-guard` and `file: llm-guard-cuda/Dockerfile`. Change detection fans out, so a change under `llm-guard/app/` rebuilds both images. Releases, retention, Trivy and Renovate all keep working unmodified; `validate-configuration.sh` needs no change since it checks `$IMAGE_NAME/Dockerfile`, which the CUDA directory has.

### Tests

`llm-guard/test.sh` takes an optional flavor argument (`cpu` default, `cuda` from the thin `llm-guard-cuda/test.sh` wrapper). Tests 1-7 unchanged; three added:

- **Test 8** — `torch.version.cuda` must be `None` for `cpu`, non-`None` for `cuda`. Direct regression guard: a CPU image must never contain CUDA torch.
- **Test 9** — startup log must report device `-1`. True for both flavors on GPU-less runners; catches `_resolve_device()` throwing or mis-parsing.
- **Test 10** (`cpu` only) — uncompressed image size under 2.5 GB. Today's image is ~7 GB uncompressed, so this fails loudly if the CUDA wheel comes back.

## Verification

- Wheel availability confirmed against `download.pytorch.org`: `torch-2.13.0+{cpu,cu130}-cp314-cp314-manylinux_2_28_{x86_64,aarch64}.whl` all exist. All of torch's own dependencies (`filelock`, `typing-extensions`, `sympy`, `networkx`, `jinja2`, `fsspec`, `mpmath`, `markupsafe`, `setuptools`) return 200 from the CPU index, so the split install resolves fully.
- CPU wheel is 191,822,516 bytes vs the CUDA wheel's 502 MiB, before counting the dropped `nvidia-*`/`triton` set — consistent with the issue's 700-900 MB estimate.
- pre-commit (shellcheck, shfmt, yamllint, actionlint, markdownlint, gitleaks) passed; pylint reports no new findings.
- `build_context` fan-out logic exercised locally against the real `*/metadata.yaml` set: a change to `llm-guard` yields `llm-guard` + `llm-guard-cuda`; unrelated and empty inputs are unaffected.
- Confirmed from `docker/build-push-action` source that `file` is pushed verbatim as `--file` with no joining against `context`, so the shared-context build is valid.

**CI results** (run 32637696863, commit `ae6f8ed`) — both images built and all 10 tests passed on each:

- Change detection fanned out correctly: a diff touching `llm-guard/app/` produced a matrix of **both** `llm-guard` and `llm-guard-cuda`, which is what proves the `build_context` support works (`llm-guard-cuda/` has no `app/` of its own).
- `llm-guard`: `torch.version.cuda=None`, **1,260,570,639 bytes uncompressed (1.26 GB)** against the 2.5 GB ceiling — down from ~7 GB.
- `llm-guard-cuda`: `torch.version.cuda=13.0`, built from `context: llm-guard` + `file: llm-guard-cuda/Dockerfile`.
- Both resolved device `-1` on the GPU-less runners, as designed.

The images were not built locally — Docker is unusable in the devcontainer used to write this (rootless podman: `cannot setup namespace using newuidmap`), so CI was the first real build. It caught one bug in the new test 9: `docker logs | grep -q` under `set -o pipefail` reports failure even on a match, because `grep -q` exits early and `docker logs` then dies on SIGPIPE with 141. Fixed in `ae6f8ed` by grepping a captured variable instead of a pipeline; the CPU build had been passing that test only by winning the race.

Compressed size against the 2,774 MiB baseline can only be measured once the image is pushed to GHCR on merge.

## Out of scope

- **zstd compression** (the issue's second secondary suggestion). The pipeline's test build uses `load: true`, which does not accept zstd output, and Docker daemons before v25 cannot pull zstd layers — that would break consumers using plain `docker pull`. The two-layer split already delivers the parallelism benefit. Worth a separate issue.
- **Rolling `spruyt-labs` timeouts back** from 30m to 15m. Different repo; do it once the shrunk image is published and a real cold pull is measured against the 15m8s baseline.
