### PR TITLE
fix(ci): render image ref and digest as single pinned reference

### DIFF
--- a/.github/scripts/create-release.sh
+++ b/.github/scripts/create-release.sh
@@ -120,11 +120,10 @@ else
 fi
 
 cat <<__RELEASE_NOTES_DELIM__ >/tmp/release-notes.md
-\`${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}\`
-\`${DIGEST}\`
+\`${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}@${DIGEST}\`
 
 \`\`\`bash
-docker pull ${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}
+docker pull ${REGISTRY}/${OWNER}/${IMAGE_NAME}:${TAG}@${DIGEST}
 \`\`\`
 
 **Upstream:** ${UPSTREAM_DISPLAY} | **Commit:** ${SHA} | **Run:** [#${RUN_NUMBER}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID})


### PR DESCRIPTION
## Problem

Release notes rendered the image reference and digest as two separate inline code spans on adjacent lines:

```
`ghcr.io/anthony-spruyt/llm-guard:1.0.27`
`sha256:9fae...`
```

Copying from the release page yields a newline-separated string rather than a usable pinned reference.

## Fix

Join them into a single code span as `<image>:<tag>@<digest>` and use the same pinned reference in the `docker pull` example, so the copied value is directly usable.